### PR TITLE
check for single sample class, not sample category on bulk sample edit

### DIFF
--- a/miso-web/src/main/webapp/scripts/hot_sample.js
+++ b/miso-web/src/main/webapp/scripts/hot_sample.js
@@ -594,18 +594,12 @@ HotTarget.sample = (function() {
               }
 
               var classes = getSampleClasses(samples);
-              var categories = Utils.array.deduplicateString(classes.map(function(sampleClass) {
-                return sampleClass.sampleCategory;
+              var classesAliases = Utils.array.deduplicateString(classes.map(function(sampleClass) {
+                return sampleClass.alias;
               }));
-              if (categories.length > 1) {
-                alert("You have selected samples of categories " + categories.join(" & ")
-                    + ". Please select samples from only one category.");
-                return;
-              }
-
-              if (categories[0] == 'Tissue Processing' && classes.length > 1) {
-                alert("You have selected samples of classes " + classes.map(Utils.array.getAlias).join(" & ")
-                    + ". Please select samples from only one tissue processing class.");
+              if (classesAliases.length > 1) {
+                alert("You have selected samples of classes " + classesAliases.join(" & ")
+                    + ". Please select samples from only one class.");
                 return;
               }
 


### PR DESCRIPTION
Matches the check in the controller, which throws an error for editing multiple sample classes.

IIRC, the JS is a holdover from when all our tissues were different sample classes but users needed to be able to edit them all together. It looks like the controller logic got changed, but the JavaScript check did not.