### PR TITLE
GLT-2836: fixed unresponsive bulk library table

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ Changes:
 * Added single Edit Dilution page
 * Changed Edit Library page to show validation messages instead of error page when saving fails
 * Fixed missing Notes section on Edit Sample page
+* Fixed a bug in the bulk library table where selecting a box position and index family for a
+  library without a library template would cause the table to become unresponsive
 
 # 0.2.174
 

--- a/miso-web/src/main/webapp/scripts/hot_library.js
+++ b/miso-web/src/main/webapp/scripts/hot_library.js
@@ -98,12 +98,14 @@ HotTarget.library = (function() {
         var readOnly = false;
         if (flat.templateAlias && flat.boxPosition && indexFamily) {
           var template = getTemplate(config, lib.parentSampleProjectId, lib.parentSampleClassId, flat.templateAlias);
-          var positionProp = n == 1 ? 'indexOneIds' : 'indexTwoIds';
-          if (template.indexFamilyId && template[positionProp] && template[positionProp][flat.boxPosition]) {
-            var index = Utils.array.getObjById(template[positionProp][flat.boxPosition], indexFamily.indices);
-            if (index) {
-              setData(index.label);
-              readOnly = true;
+          if (template) {
+            var positionProp = n == 1 ? 'indexOneIds' : 'indexTwoIds';
+            if (template.indexFamilyId && template[positionProp] && template[positionProp][flat.boxPosition]) {
+              var index = Utils.array.getObjById(template[positionProp][flat.boxPosition], indexFamily.indices);
+              if (index) {
+                setData(index.label);
+                readOnly = true;
+              }
             }
           }
         }


### PR DESCRIPTION
Issue occurred when selecting a box position and index family when no library template was chosen