### PR TITLE
GLT-2829: added script for building versioned docs

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DOCS_BRANCH=gh-pages
+
+TEMP_CONFIG=_version_config.yml
+TEMP_BRANCH=temp_docs
+START_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+git fetch --tags
+
+pushd docs
+rm -rf ./_site
+
+# Build versioned docs for each minor version
+VERSIONS=($(git tag | grep '^v[0-9]*\.[0-9]*\.[0-9]*$' | cut -d . -f 1,2 - | sort | uniq))
+for MINOR in ${VERSIONS[@]}
+do
+  PATCH=$(git tag | grep "^${MINOR}\.[0-9]*$" | cut -d . -f 3 | sort -n | tail -n1)
+  echo -e "\nBuilding ${MINOR}.${PATCH} as '${MINOR}.x'..."
+  git checkout ${MINOR}.${PATCH}
+  V=${MINOR:1}.x
+  echo "baseurl : /miso-lims/${V}" > ${TEMP_CONFIG}
+  jekyll build --config _config.yml,${TEMP_CONFIG} -d _site/${V}/
+done
+
+# Add "latest" as copy of most recent version
+echo -e "\nRebuilding ${MINOR}.${PATCH} as 'latest'..."
+echo "baseurl : /miso-lims/latest" > ${TEMP_CONFIG}
+jekyll build --config _config.yml,${TEMP_CONFIG} -d _site/latest/
+rm ${TEMP_CONFIG}
+
+# Add /index.html that redirects to /miso-lims/latest/
+echo "<html>
+  <head>
+    <meta http-equiv=\"Refresh\" content=\"0; url=/miso-lims/latest/\" />
+  </head>
+  <body>
+    <p>See the latest version of the docs <a href=\"/miso-lims/latest/\">here</a></p>
+  </body>
+</html>" > _site/index.html
+popd
+
+# push to GitHub docs branch
+echo -e "\nDeploying to GitHub..."
+git checkout -b ${TEMP_BRANCH}
+rm .gitignore
+git add docs/_site/
+git commit -m "Built versioned site to ${MINOR}.${PATCH}"
+git subtree split --prefix docs/_site -b gh-pages
+git push -f origin gh-pages:gh-pages
+git branch -D gh-pages
+git checkout .gitignore
+git checkout ${START_BRANCH}
+git branch -D ${TEMP_BRANCH}
+

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/TagUtils.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/TagUtils.java
@@ -5,6 +5,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import uk.ac.bbsrc.tgac.miso.Version;
+
 public class TagUtils {
 
   private static final Logger log = Logger.getLogger(TagUtils.class);
@@ -48,6 +50,14 @@ public class TagUtils {
 
   private static Authentication getAuthentication() {
     return SecurityContextHolder.getContextHolderStrategy().getContext().getAuthentication();
+  }
+
+  public static String docsVersion() {
+    if (Version.VERSION.matches("^\\d*\\.\\d*\\.\\d*$")) {
+      return Version.VERSION.substring(0, Version.VERSION.lastIndexOf(".")) + ".x";
+    } else {
+      return "latest";
+    }
   }
 
 }

--- a/miso-web/src/main/webapp/WEB-INF/header.jsp
+++ b/miso-web/src/main/webapp/WEB-INF/header.jsp
@@ -115,7 +115,7 @@
   <div class="cell">
     <sec:authorize access="isAuthenticated()">
       <div id="loggedInBanner">
-        <a href="http://miso-lims.github.io/miso-lims/usr/user-manual-table-of-contents.html">Help</a> |
+        <a href="http://miso-lims.github.io/miso-lims/${miso:docsVersion()}/usr/user-manual-table-of-contents.html">Help</a> |
         <a href="https://gitter.im/miso-lims/users">Chat</a> |
         <c:if test="${misoBugUrl != null}">
           <a href="${misoBugUrl}" target="_blank">Report a problem</a> |

--- a/miso-web/src/main/webapp/WEB-INF/miso-form.tld
+++ b/miso-web/src/main/webapp/WEB-INF/miso-form.tld
@@ -420,6 +420,12 @@
         <function-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.TagUtils</function-class>
         <function-signature>boolean isAdmin()</function-signature>
     </function>
+    
+    <function>
+        <name>docsVersion</name>
+        <function-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.TagUtils</function-class>
+        <function-signature>String docsVersion()</function-signature>
+    </function>
 
 
 </taglib>


### PR DESCRIPTION
For now, this is only going to build 0.2.x. Will make more sense after 1.0 when our regular releases are minor versions and it builds 1.1.x, 1.2.x, etc. where patch versions may contain docs updates to include in the same minor version.

I'll add this to the release procedure after it's merged. We'll have to change the GitHub settings to use `gh-pages` after the next release.