### PR TITLE
Add 'Export' to Docker instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ Launch the detailed sample demo with docker-compose:
 
 ```bash
 cd miso-lims-compose
-export MISO_DB_USER=tgaclims && export MISO_DB=lims && export MISO_DB_PASSWORD_FILE=./.miso_db_password && MISO_TAG=latest
+export MISO_DB_USER=tgaclims && export MISO_DB=lims && export MISO_DB_PASSWORD_FILE=./.miso_db_password && export MISO_TAG=latest
 echo "changeme" > ./.miso_db_password
 docker-compose -f demo.detailed.yml up
 ```


### PR DESCRIPTION
It complained at me that MISO_TAG wasn't set when I tried running it