### PR TITLE
[GLT-2916] Patch 'No Scientific Name' bug

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ Changes:
     was very limited
   * Fixed users being editable when using LDAP/AD authentication
   * Fixed migration that altered library aliquot created dates
+  * Fixed intermittent bug preventing receiving libraries due to Scientific Name (and potentially other fields) not saving correctly
 
 # 0.2.183
 

--- a/miso-web/src/main/webapp/scripts/hot_library_receipt.js
+++ b/miso-web/src/main/webapp/scripts/hot_library_receipt.js
@@ -34,13 +34,23 @@ HotTarget.libraryReceipt = (function() {
           if (!flat.sample) {
             flat.sample = {};
           }
+
           col.libraryUnpack(lib.sample, flat.sample, setCellMeta);
+
+
         };
         col.libraryPack = col.pack;
         col.pack = function(lib, flat, errorHandler) {
           if (!flat.sample) {
             flat.sample = {};
           }
+
+          // Sometimes sample properties don't go into the nested subobject, but become a field called
+          // "sample.[name]". If this happens, it breaks validation on save. Move it back.
+          if(Object.keys(flat).filter(function(s){return s === col.data}).length > 0){
+            eval("flat.sample." + col.data.substring(7) + " = '" + flat[col.data] + "';");
+          }
+
           col.libraryPack(lib.sample, flat.sample, errorHandler);
         };
         if (col.update) {

--- a/miso-web/src/main/webapp/scripts/hot_library_receipt.js
+++ b/miso-web/src/main/webapp/scripts/hot_library_receipt.js
@@ -30,30 +30,28 @@ HotTarget.libraryReceipt = (function() {
             col.depends = 'sample.' + col.depends;
           }
         }
+
         col.libraryUnpack = col.unpack;
         col.unpack = function(lib, flat, setCellMeta) {
           if (!flat.sample) {
             flat.sample = {};
           }
-
           col.libraryUnpack(lib.sample, flat.sample, setCellMeta);
-
-
         };
+
         col.libraryPack = col.pack;
         col.pack = function(lib, flat, errorHandler) {
           if (!flat.sample) {
             flat.sample = {};
           }
-
           // Sometimes sample properties don't go into the nested subobject, but become a field called
           // "sample.[name]". If this happens, it breaks validation on save. Move it back.
           if(flat.hasOwnProperty(col.data)){
             flat.sample[col.initialData] = flat[col.data];
           }
-
           col.libraryPack(lib.sample, flat.sample, errorHandler);
         };
+
         if (col.update) {
           col.libraryUpdate = col.update;
           col.update = function(lib, flat, flatProperty, value, setReadOnly, setOptions, setData) {

--- a/miso-web/src/main/webapp/scripts/hot_library_receipt.js
+++ b/miso-web/src/main/webapp/scripts/hot_library_receipt.js
@@ -19,6 +19,7 @@ HotTarget.libraryReceipt = (function() {
       var libColumns = HotTarget.library.createColumns(config, create, data);
 
       samColumns.forEach(function(col, colIndex) {
+        col.initialData = col.data;
         col.data = 'sample.' + col.data;
         if (col.depends) {
           if (Array.isArray(col.depends)) {
@@ -48,7 +49,7 @@ HotTarget.libraryReceipt = (function() {
           // Sometimes sample properties don't go into the nested subobject, but become a field called
           // "sample.[name]". If this happens, it breaks validation on save. Move it back.
           if(flat.hasOwnProperty(col.data)){
-            eval("flat.sample." + col.data.substring(7) + " = '" + flat[col.data] + "';");
+            flat.sample[col.initialData] = flat[col.data];
           }
 
           col.libraryPack(lib.sample, flat.sample, errorHandler);

--- a/miso-web/src/main/webapp/scripts/hot_library_receipt.js
+++ b/miso-web/src/main/webapp/scripts/hot_library_receipt.js
@@ -47,7 +47,7 @@ HotTarget.libraryReceipt = (function() {
 
           // Sometimes sample properties don't go into the nested subobject, but become a field called
           // "sample.[name]". If this happens, it breaks validation on save. Move it back.
-          if(Object.keys(flat).filter(function(s){return s === col.data}).length > 0){
+          if(flat.hasOwnProperty(col.data)){
             eval("flat.sample." + col.data.substring(7) + " = '" + flat[col.data] + "';");
           }
 

--- a/miso-web/src/main/webapp/scripts/list_library.js
+++ b/miso-web/src/main/webapp/scripts/list_library.js
@@ -82,7 +82,7 @@ ListTarget.library = {
             sampleClassId: Constants.isDetailedSample ? result.sampleClass.id : null
           };
         }, function(result) {
-          return result.quanitity;
+          return result.quantity;
         });
       }
     }];


### PR DESCRIPTION
Putting periods in field names should cause Handsontable to create nested objects and fields. In rare (and as of yet unknown) circumstances, it fails to do this, and consistently does so on flat.sample.scientificName, creating a situation where on save there is an extra field flat["sample.scientificName"] which contains a string but flat.sample.scientificName is null. Detects when this happens and forces the value back to the correct place to enable saving. Does not fix the underlying issue. Can't seem to pinpoint it, this broken field seems to pop up at the call to pack.

Also corrects a typo in an unrelated function. Don't know if that's ever called.