### PR TITLE
[GLT-2922] Check for null pool

### DIFF
--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolService.java
@@ -282,6 +282,7 @@ public class DefaultPoolService implements PoolService, PaginatedDataSource<Pool
   }
 
   private Set<String> getAllBadIndices(Pool pool){
+    if(pool == null) return new HashSet<>();
     Set<String> indices = pool.getDuplicateIndicesSequences();
     indices.addAll(pool.getNearDuplicateIndicesSequences());
     return indices;


### PR DESCRIPTION
When creating a new Pool, validation is called with a null
'beforeChange' pool. Prevent NPE in this case while preserving check for
conflicting indices