### PR TITLE
GLT-2969 Show message when Validation Error occurs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 Changes:
-
+  * Show detailed messages rather than generic Server Errors in validation failure cases
 
 
 # 0.2.187

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
@@ -91,6 +91,7 @@ import uk.ac.bbsrc.tgac.miso.core.service.RunService;
 import uk.ac.bbsrc.tgac.miso.core.service.SampleClassService;
 import uk.ac.bbsrc.tgac.miso.core.service.SampleService;
 import uk.ac.bbsrc.tgac.miso.core.service.SampleValidRelationshipService;
+import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationException;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.NamingScheme;
 import uk.ac.bbsrc.tgac.miso.core.util.AliasComparator;
 import uk.ac.bbsrc.tgac.miso.core.util.AlphanumericComparator;
@@ -408,7 +409,7 @@ public class EditLibraryController {
           if (sampleClass == null) {
             sampleClass = detailed.getSampleClass();
           } else if (sampleClass.getId() != detailed.getSampleClass().getId()) {
-            throw new IOException("Can only create libraries when samples all have the same class.");
+            throw new ValidationException("Can only create libraries when samples all have the same class.");
           }
         } else {
           hasPlain = true;

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/component/ExceptionHandlerAdvice.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/component/ExceptionHandlerAdvice.java
@@ -9,6 +9,10 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.ModelAndView;
+import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationError;
+import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationException;
+
+import java.util.stream.Collectors;
 
 @ControllerAdvice("uk.ac.bbsrc.tgac.miso.webapp.controller")
 public class ExceptionHandlerAdvice {
@@ -39,6 +43,18 @@ public class ExceptionHandlerAdvice {
     logException(e);
     return withMessages("Server Error",
         "An unexpected error has occurred. If the problem persists, please report it to your MISO administrators", true);
+  }
+
+  @ExceptionHandler(ValidationException.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ModelAndView showValidationErrors(final ValidationException e){
+    // A ValidationException might have >1 ValidationError. Show all their messages
+    return withMessages("Input Validation Error",
+            e.getErrors()
+              .stream()
+              .map(ValidationError::getMessage)
+              .collect(Collectors.joining("\n")),
+            true);
   }
 
   private ModelAndView fromExceptionMessage(String genericMessage, Exception e, boolean possibleBug) {


### PR DESCRIPTION
In the case of ValidationException being thrown when creating a new
page, the generic Server Error page appears without explaining the
error. Define new page that prints all the errors.