### PR TITLE
GLT-2944 Inhibit duplicate-index actions on Pool Orders

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 Changes:
-
+  * Prevent creation of Pool Orders with duplicate indices
+  * Prevent linking of Pools with duplicate indices to Pool Orders
 
 
 # 0.2.188

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
@@ -151,10 +151,10 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
       errors.add(new ValidationError("Non-draft order must include at least one library aliquot"));
     }
 
-    if(strictPools) validateIndices(object, beforeChange, errors);
+    if(strictPools) validateNoNewDuplicateIndices(object, beforeChange, errors);
   }
 
-  private void validateIndices(PoolOrder object, PoolOrder beforeChange, List<ValidationError> errors){
+  private void validateNoNewDuplicateIndices(PoolOrder object, PoolOrder beforeChange, List<ValidationError> errors){
     // Work based on whether bad index count increases, rather than >0, in case Pool Orders already exist w >1
     if(indexChecker.getDuplicateIndicesSequences(beforeChange).size()
             < indexChecker.getDuplicateIndicesSequences(object).size()

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
@@ -3,6 +3,7 @@ package uk.ac.bbsrc.tgac.miso.service.impl;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -25,6 +26,7 @@ import uk.ac.bbsrc.tgac.miso.core.service.SequencingParametersService;
 import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationError;
 import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationResult;
 import uk.ac.bbsrc.tgac.miso.core.store.DeletionStore;
+import uk.ac.bbsrc.tgac.miso.core.util.IndexChecker;
 import uk.ac.bbsrc.tgac.miso.core.util.PaginationFilter;
 import uk.ac.bbsrc.tgac.miso.persistence.PoolOrderDao;
 import uk.ac.bbsrc.tgac.miso.persistence.SaveDao;
@@ -57,6 +59,9 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
 
   @Autowired
   private SequencingOrderService sequencingOrderService;
+
+  @Autowired
+  private IndexChecker indexChecker;
 
   @Override
   public DeletionStore getDeletionStore() {
@@ -139,6 +144,27 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
 
     if (!object.isDraft() && object.getOrderLibraryAliquots().isEmpty()) {
       errors.add(new ValidationError("Non-draft order must include at least one library aliquot"));
+    }
+
+    // Work based on whether bad index count increases, rather than >0, in case Pool Orders already exist w >1
+    if(indexChecker.getDuplicateIndicesSequences(beforeChange).size()
+            < indexChecker.getDuplicateIndicesSequences(object).size()
+      || indexChecker.getNearDuplicateIndicesSequences(beforeChange).size()
+            < indexChecker.getNearDuplicateIndicesSequences(object).size()){
+      Set<String> indices = indexChecker.getDuplicateIndicesSequences(object);
+      indices.addAll(indexChecker.getNearDuplicateIndicesSequences(object));
+      Set<String> bcIndices = indexChecker.getDuplicateIndicesSequences(beforeChange);
+      bcIndices.addAll(indexChecker.getNearDuplicateIndicesSequences(beforeChange));
+      String errorMessage = String.format("Pools may not contain Library Aliquots with indices with %d or " +
+                      "fewer positions of difference, please address the following conflicts: ",
+              indexChecker.getWarningMismatches());
+      indices.removeAll(bcIndices);
+
+      for (String index : indices){
+        errorMessage += index + " ";
+      }
+
+      errors.add(new ValidationError(errorMessage));
     }
   }
 

--- a/miso-web/src/main/webapp/scripts/form_poolorder.js
+++ b/miso-web/src/main/webapp/scripts/form_poolorder.js
@@ -326,12 +326,16 @@ FormTarget.poolorder = (function($) {
   }
 
   function doSetPool(form, pool) {
+  if(pool && (pool.duplicateIndices || pool.nearDuplicateIndices)){
+    Utils.showOkDialog('Error', ['Selected pool contains duplicate or near duplicate indices.']);
+  } else {
     form.updateField('poolId', {
       value: pool ? pool.id : null,
       label: pool ? pool.alias : 'not linked',
       link: pool ? Urls.ui.pools.edit(pool.id) : null
     });
     form.save();
+    }
   }
 
   function unlinkPool(form) {


### PR DESCRIPTION
* Check on adding Library Aliquots (& therefore, Pool Order creation) for duplicate & near duplicate indices, block action
* Check if pool is known to contain duplicate or near duplicate indices on linking to pool order, block action