### PR TITLE
GLT-2979 Pool Order changelogs

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolOrder.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolOrder.java
@@ -1,10 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.core.data.impl;
 
 import java.io.Serializable;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
@@ -23,9 +20,29 @@ import javax.persistence.TemporalType;
 import com.eaglegenomics.simlims.core.User;
 
 import uk.ac.bbsrc.tgac.miso.core.data.*;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.PoolChangeLog;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.PoolOrderChangeLog;
 
 @Entity
-public class PoolOrder implements Deletable, Identifiable, Serializable, Timestamped {
+public class PoolOrder implements Deletable, Identifiable, Serializable, Timestamped, ChangeLoggable {
+
+  @OneToMany(targetEntity = PoolOrderChangeLog.class, mappedBy = "poolOrder", cascade = CascadeType.REMOVE)
+  private final Collection<ChangeLog> changeLog = new ArrayList<>();
+
+  @Override
+  public Collection<ChangeLog> getChangeLog() {
+    return changeLog;
+  }
+
+  @Override
+  public ChangeLog createChangeLog(String summary, String columnsChanged, User user) {
+    PoolOrderChangeLog changeLog = new PoolOrderChangeLog();
+    changeLog.setPoolOrder(this);
+    changeLog.setSummary(summary);
+    changeLog.setColumnsChanged(columnsChanged);
+    changeLog.setUser(user);
+    return changeLog;
+  }
 
   public enum Status {
     OUTSTANDING("Outstanding"), DRAFT("Draft"), FULFILLED("Fulfilled");

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolOrder.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolOrder.java
@@ -20,7 +20,6 @@ import javax.persistence.TemporalType;
 import com.eaglegenomics.simlims.core.User;
 
 import uk.ac.bbsrc.tgac.miso.core.data.*;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.PoolChangeLog;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.PoolOrderChangeLog;
 
 @Entity

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/changelog/PoolOrderChangeLog.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/changelog/PoolOrderChangeLog.java
@@ -1,0 +1,56 @@
+package uk.ac.bbsrc.tgac.miso.core.data.impl.changelog;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Table;
+
+import uk.ac.bbsrc.tgac.miso.core.data.AbstractChangeLog;
+import uk.ac.bbsrc.tgac.miso.core.data.Pool;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolOrder;
+
+@Entity
+@Table(appliesTo = "PoolOrderChangeLog", indexes = {
+        @Index(name = "PoolOrderChangeLog_poolOrderId_changeTime", columnNames = { "poolOrderId", "changeTime" }) })
+public class PoolOrderChangeLog extends AbstractChangeLog {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long poolOrderChangeLogId;
+
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = PoolOrder.class)
+    @JoinColumn(name = "poolOrderId", nullable = false, updatable = false)
+    private PoolOrder poolOrder;
+
+    @Override
+    public Long getId() {
+        return poolOrder.getId();
+    }
+
+    @Override
+    public void setId(Long id) {
+        poolOrder.setId(id);
+    }
+
+    public Long getPoolOrderChangeLogId() {
+        return poolOrderChangeLogId;
+    }
+
+    public PoolOrder getPoolOrder() {
+        return poolOrder;
+    }
+
+    public void setPoolOrder(PoolOrder poolOrder) {
+        this.poolOrder = poolOrder;
+    }
+
+}

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/changelog/PoolOrderChangeLog.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/changelog/PoolOrderChangeLog.java
@@ -12,8 +12,6 @@ import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Table;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractChangeLog;
-import uk.ac.bbsrc.tgac.miso.core.data.Pool;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolOrder;
 
 @Entity

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
@@ -227,6 +227,11 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
       }
     }
 
+    if(to.getPool() != from.getPool()) changeLogService.create(
+            to.createChangeLog(from.getPool() == null? "Pool unlinked."
+                            : "Associated pool: " + from.getPool().getAlias(),
+                    "poolId",
+                    authorizationManager.getCurrentUser()));
     to.setPool(from.getPool());
     to.setSequencingOrder(from.getSequencingOrder());
   }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
@@ -290,12 +290,28 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
       }
     }
 
-    if(to.getPool() != from.getPool()) changeLogService.create(
-            to.createChangeLog(from.getPool() == null? "Pool unlinked."
-                            : "Associated pool: " + from.getPool().getAlias(),
-                    "poolId",
-                    authorizationManager.getCurrentUser()));
+    if(from.getPool() == null && to.getPool() != null){
+      changeLogService.create(to.createChangeLog("Pool unlinked.",
+              "poolId",
+              authorizationManager.getCurrentUser()));
+    }else if(to.getPool() == null && from.getPool() != null){
+      changeLogService.create(
+              to.createChangeLog("Associated pool: " + from.getPool().getAlias(),
+                      "poolId",
+                      authorizationManager.getCurrentUser()));
+    }
     to.setPool(from.getPool());
+
+    if(from.getSequencingOrder() == null && to.getSequencingOrder() != null){
+      changeLogService.create(to.createChangeLog("Sequencing order unlinked.",
+              "sequencingOrderId",
+              authorizationManager.getCurrentUser()));
+    }else if(to.getSequencingOrder() == null && from.getSequencingOrder() != null){
+      changeLogService.create(
+              to.createChangeLog("Associated sequencing order.",
+                      "sequencingOrderId",
+                      authorizationManager.getCurrentUser()));
+    }
     to.setSequencingOrder(from.getSequencingOrder());
   }
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
@@ -19,11 +19,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolOrder;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.view.PoolElement;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.security.AuthorizationManager;
-import uk.ac.bbsrc.tgac.miso.core.service.LibraryAliquotService;
-import uk.ac.bbsrc.tgac.miso.core.service.OrderPurposeService;
-import uk.ac.bbsrc.tgac.miso.core.service.PoolService;
-import uk.ac.bbsrc.tgac.miso.core.service.SequencingOrderService;
-import uk.ac.bbsrc.tgac.miso.core.service.SequencingParametersService;
+import uk.ac.bbsrc.tgac.miso.core.service.*;
 import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationError;
 import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationResult;
 import uk.ac.bbsrc.tgac.miso.core.store.DeletionStore;
@@ -39,7 +35,6 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
 
   @Value("${miso.pools.strictIndexChecking:false}")
   private Boolean strictPools;
-
 
   @Autowired
   private PoolOrderDao poolOrderDao;
@@ -68,6 +63,9 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
   @Autowired
   private IndexChecker indexChecker;
 
+  @Autowired
+  private ChangeLogService changeLogService;
+
   @Override
   public DeletionStore getDeletionStore() {
     return deletionStore;
@@ -81,6 +79,10 @@ public class DefaultPoolOrderService extends AbstractSaveService<PoolOrder> impl
   @Override
   public SaveDao<PoolOrder> getDao() {
     return poolOrderDao;
+  }
+
+  public void setChangeLogService(ChangeLogService changeLogService) {
+    this.changeLogService = changeLogService;
   }
 
   @Override

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolOrderController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolOrderController.java
@@ -66,6 +66,7 @@ public class EditPoolOrderController {
     }
     model.put("title", "Pool Order " + orderId);
     model.put("pageMode", "edit");
+    model.put("poolOrder", order);
     return orderPage(order, model);
   }
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolOrderController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolOrderController.java
@@ -66,13 +66,13 @@ public class EditPoolOrderController {
     }
     model.put("title", "Pool Order " + orderId);
     model.put("pageMode", "edit");
-    model.put("poolOrder", order);
     return orderPage(order, model);
   }
 
   private ModelAndView orderPage(PoolOrder order, ModelMap model) throws JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     PoolOrderDto dto = Dtos.asDto(order, indexChecker);
+    model.put("poolOrder", order);
     model.put("orderDto", mapper.writeValueAsString(dto));
     model.put("libraryDtos", dto.getOrderAliquots());
     return new ModelAndView("/WEB-INF/pages/editPoolOrder.jsp", model);

--- a/miso-web/src/main/webapp/WEB-INF/pages/editPoolOrder.jsp
+++ b/miso-web/src/main/webapp/WEB-INF/pages/editPoolOrder.jsp
@@ -52,6 +52,10 @@
   });
 </script>
 
+<div class="noPrint">
+  <miso:changelog item="${poolOrder}"/>
+</div>
+
 </div>
 </div>
 

--- a/sqlstore/src/main/resources/db/migration/V8000__pool_order_changelog.sql
+++ b/sqlstore/src/main/resources/db/migration/V8000__pool_order_changelog.sql
@@ -8,3 +8,4 @@ CREATE TABLE PoolOrderChangeLog (
   CONSTRAINT fk_poolOrderChangeLog_pool FOREIGN KEY (poolOrderId) REFERENCES PoolOrder(poolOrderId),
   CONSTRAINT fk_poolOrderChangeLog_user FOREIGN KEY (userId) REFERENCES User(userId)
 ) Engine=InnoDB DEFAULT CHARSET=utf8;
+

--- a/sqlstore/src/main/resources/db/migration/V8000__pool_order_changelog.sql
+++ b/sqlstore/src/main/resources/db/migration/V8000__pool_order_changelog.sql
@@ -1,0 +1,10 @@
+CREATE TABLE PoolOrderChangeLog (
+  poolOrderChangeLogId bigint(20) PRIMARY KEY AUTO_INCREMENT,
+  poolOrderId bigint(20) NOT NULL,
+  columnsChanged varchar(500) NOT NULL,
+  userId bigint(20) NOT NULL,
+  message longtext NOT NULL,
+  changeTime timestamp DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_poolOrderChangeLog_pool FOREIGN KEY (poolOrderId) REFERENCES PoolOrder(poolOrderId),
+  CONSTRAINT fk_poolOrderChangeLog_user FOREIGN KEY (userId) REFERENCES User(userId)
+) Engine=InnoDB DEFAULT CHARSET=utf8;

--- a/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
+++ b/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
@@ -9,21 +9,22 @@ FOR EACH ROW
   BEGIN
   DECLARE log_message varchar(500) CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
-        CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,
+        CASE WHEN NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,
         CASE WHEN (NEW.description IS NULL) <> (OLD.description IS NULL) OR NEW.description <> OLD.description THEN CONCAT('description: ', COALESCE(OLD.description, 'n/a'), ' → ', COALESCE(NEW.description, 'n/a')) END,
-        CASE WHEN (NEW.partitions IS NULL) <> (OLD.partitions IS NULL) OR NEW.partitions <> OLD.partitions THEN CONCAT('partitions: ', COALESCE(OLD.partitions, 'n/a'), ' → ', COALESCE(NEW.partitions, 'n/a')) END,         CASE WHEN (NEW.draft IS NULL) <> (OLD.draft IS NULL) OR NEW.draft <> OLD.draft THEN CONCAT('draft: ', IF(OLD.draft = 0, 'No', 'Yes'), ' → ', IF(NEW.draft = 0, 'No', 'Yes')) END,
-        CASE WHEN (NEW.createdBy IS NULL) <> (OLD.createdBy IS NULL) OR NEW.createdBy <> OLD.createdBy THEN CONCAT('created by: ', COALESCE(OLD.createdBy, 'n/a'), ' → ', COALESCE(NEW.createdBy, 'n/a')) END,
-        CASE WHEN (NEW.creationDate IS NULL) <> (OLD.creationDate IS NULL) OR NEW.creationDate <> OLD.creationDate THEN CONCAT('creation date: ', COALESCE(OLD.creationDate, 'n/a'), ' → ', COALESCE(NEW.creationDate, 'n/a')) END);
+        CASE WHEN (NEW.partitions IS NULL) <> (OLD.partitions IS NULL) OR NEW.partitions <> OLD.partitions THEN CONCAT('partitions: ', COALESCE(OLD.partitions, 'n/a'), ' → ', COALESCE(NEW.partitions, 'n/a')) END,
+        CASE WHEN NEW.draft <> OLD.draft THEN CONCAT('draft: ', IF(OLD.draft = 0, 'No', 'Yes'), ' → ', IF(NEW.draft = 0, 'No', 'Yes')) END,
+        CASE WHEN NEW.createdBy <> OLD.createdBy THEN CONCAT('created by: ', COALESCE(OLD.createdBy, 'n/a'), ' → ', COALESCE(NEW.createdBy, 'n/a')) END,
+        CASE WHEN NEW.creationDate <> OLD.creationDate THEN CONCAT('creation date: ', COALESCE(OLD.creationDate, 'n/a'), ' → ', COALESCE(NEW.creationDate, 'n/a')) END);
   IF log_message IS NOT NULL AND log_message <> '' THEN
     INSERT INTO PoolOrderChangeLog(poolOrderId, columnsChanged, userId, message, changeTime) VALUES (
       NEW.poolOrderId,
       COALESCE(CONCAT_WS(',',
-        CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN 'alias' END,
+        CASE WHEN NEW.alias <> OLD.alias THEN 'alias' END,
         CASE WHEN (NEW.description IS NULL) <> (OLD.description IS NULL) OR NEW.description <> OLD.description THEN 'description' END,
         CASE WHEN (NEW.partitions IS NULL) <> (OLD.partitions IS NULL) OR NEW.partitions <> OLD.partitions THEN 'partitions' END,
-        CASE WHEN (NEW.draft IS NULL) <> (OLD.draft IS NULL) OR NEW.draft <> OLD.draft THEN 'draft' END,
-        CASE WHEN (NEW.createdBy IS NULL) <> (OLD.createdBy IS NULL) OR NEW.createdBy <> OLD.createdBy THEN 'createdBy' END,
-        CASE WHEN (NEW.creationDate IS NULL) <> (OLD.creationDate IS NULL) OR NEW.creationDate <> OLD.creationDate THEN 'creationDate' END), ''),
+        CASE WHEN NEW.draft <> OLD.draft THEN 'draft' END,
+        CASE WHEN NEW.createdBy <> OLD.createdBy THEN 'createdBy' END,
+        CASE WHEN NEW.creationDate <> OLD.creationDate THEN 'creationDate' END), ''),
       NEW.updatedBy,
       log_message,
       NEW.lastUpdated);

--- a/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
+++ b/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
@@ -11,7 +11,6 @@ FOR EACH ROW
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,
         CASE WHEN (NEW.description IS NULL) <> (OLD.description IS NULL) OR NEW.description <> OLD.description THEN CONCAT('description: ', COALESCE(OLD.description, 'n/a'), ' → ', COALESCE(NEW.description, 'n/a')) END,
-        CASE WHEN (NEW.purposeId IS NULL) <> (OLD.purposeId IS NULL) OR NEW.purposeId <> OLD.purposeId THEN CONCAT('purposeId: ', COALESCE(OLD.purposeId, 'n/a'), ' → ', COALESCE(NEW.purposeId, 'n/a')) END, 
         CASE WHEN (NEW.partitions IS NULL) <> (OLD.partitions IS NULL) OR NEW.partitions <> OLD.partitions THEN CONCAT('partitions: ', COALESCE(OLD.partitions, 'n/a'), ' → ', COALESCE(NEW.partitions, 'n/a')) END,         CASE WHEN (NEW.draft IS NULL) <> (OLD.draft IS NULL) OR NEW.draft <> OLD.draft THEN CONCAT('draft: ', IF(OLD.draft = 0, 'No', 'Yes'), ' → ', IF(NEW.draft = 0, 'No', 'Yes')) END,
         CASE WHEN (NEW.createdBy IS NULL) <> (OLD.createdBy IS NULL) OR NEW.createdBy <> OLD.createdBy THEN CONCAT('created by: ', COALESCE(OLD.createdBy, 'n/a'), ' → ', COALESCE(NEW.createdBy, 'n/a')) END,
         CASE WHEN (NEW.creationDate IS NULL) <> (OLD.creationDate IS NULL) OR NEW.creationDate <> OLD.creationDate THEN CONCAT('creation date: ', COALESCE(OLD.creationDate, 'n/a'), ' → ', COALESCE(NEW.creationDate, 'n/a')) END);
@@ -21,7 +20,6 @@ FOR EACH ROW
       COALESCE(CONCAT_WS(',',
         CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN 'alias' END,
         CASE WHEN (NEW.description IS NULL) <> (OLD.description IS NULL) OR NEW.description <> OLD.description THEN 'description' END,
-        CASE WHEN (NEW.purposeId IS NULL) <> (OLD.purposeId IS NULL) OR NEW.purposeId <> OLD.purposeId THEN 'purposeId' END,
         CASE WHEN (NEW.partitions IS NULL) <> (OLD.partitions IS NULL) OR NEW.partitions <> OLD.partitions THEN 'partitions' END,
         CASE WHEN (NEW.draft IS NULL) <> (OLD.draft IS NULL) OR NEW.draft <> OLD.draft THEN 'draft' END,
         CASE WHEN (NEW.createdBy IS NULL) <> (OLD.createdBy IS NULL) OR NEW.createdBy <> OLD.createdBy THEN 'createdBy' END,

--- a/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
+++ b/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
@@ -1,9 +1,46 @@
-DROP TRIGGER IF EXISTS PoolOrderInsert;
+-- StartNoTest
+DELIMITER //
+
+DROP TRIGGER IF EXISTS BeforeInsertPoolOrder//
+
+DROP TRIGGER IF EXISTS PoolOrderChange//
+CREATE TRIGGER PoolOrderChange BEFORE UPDATE ON PoolOrder
+FOR EACH ROW
+  BEGIN
+  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  SET log_message = CONCAT_WS(', ',
+        CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,
+        CASE WHEN (NEW.description IS NULL) <> (OLD.description IS NULL) OR NEW.description <> OLD.description THEN CONCAT('description: ', COALESCE(OLD.description, 'n/a'), ' → ', COALESCE(NEW.description, 'n/a')) END,
+        CASE WHEN (NEW.purposeId IS NULL) <> (OLD.purposeId IS NULL) OR NEW.purposeId <> OLD.purposeId THEN CONCAT('purposeId: ', COALESCE(OLD.purposeId, 'n/a'), ' → ', COALESCE(NEW.purposeId, 'n/a')) END, 
+        CASE WHEN (NEW.partitions IS NULL) <> (OLD.partitions IS NULL) OR NEW.partitions <> OLD.partitions THEN CONCAT('partitions: ', COALESCE(OLD.partitions, 'n/a'), ' → ', COALESCE(NEW.partitions, 'n/a')) END,         CASE WHEN (NEW.draft IS NULL) <> (OLD.draft IS NULL) OR NEW.draft <> OLD.draft THEN CONCAT('draft: ', IF(OLD.draft = 0, 'No', 'Yes'), ' → ', IF(NEW.draft = 0, 'No', 'Yes')) END,
+        CASE WHEN (NEW.createdBy IS NULL) <> (OLD.createdBy IS NULL) OR NEW.createdBy <> OLD.createdBy THEN CONCAT('created by: ', COALESCE(OLD.createdBy, 'n/a'), ' → ', COALESCE(NEW.createdBy, 'n/a')) END,
+        CASE WHEN (NEW.creationDate IS NULL) <> (OLD.creationDate IS NULL) OR NEW.creationDate <> OLD.creationDate THEN CONCAT('creation date: ', COALESCE(OLD.creationDate, 'n/a'), ' → ', COALESCE(NEW.creationDate, 'n/a')) END);
+  IF log_message IS NOT NULL AND log_message <> '' THEN
+    INSERT INTO PoolOrderChangeLog(poolOrderId, columnsChanged, userId, message, changeTime) VALUES (
+      NEW.poolOrderId,
+      COALESCE(CONCAT_WS(',',
+        CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN 'alias' END,
+        CASE WHEN (NEW.description IS NULL) <> (OLD.description IS NULL) OR NEW.description <> OLD.description THEN 'description' END,
+        CASE WHEN (NEW.purposeId IS NULL) <> (OLD.purposeId IS NULL) OR NEW.purposeId <> OLD.purposeId THEN 'purposeId' END,
+        CASE WHEN (NEW.partitions IS NULL) <> (OLD.partitions IS NULL) OR NEW.partitions <> OLD.partitions THEN 'partitions' END,
+        CASE WHEN (NEW.draft IS NULL) <> (OLD.draft IS NULL) OR NEW.draft <> OLD.draft THEN 'draft' END,
+        CASE WHEN (NEW.createdBy IS NULL) <> (OLD.createdBy IS NULL) OR NEW.createdBy <> OLD.createdBy THEN 'createdBy' END,
+        CASE WHEN (NEW.creationDate IS NULL) <> (OLD.creationDate IS NULL) OR NEW.creationDate <> OLD.creationDate THEN 'creationDate' END), ''),
+      NEW.updatedBy,
+      log_message,
+      NEW.lastUpdated);
+  END IF;
+  END//
+
+DROP TRIGGER IF EXISTS PoolOrderInsert//
 CREATE TRIGGER PoolOrderInsert AFTER INSERT ON PoolOrder
 FOR EACH ROW
   INSERT INTO PoolOrderChangeLog(poolOrderId, columnsChanged, userId, message, changeTime) VALUES (
     NEW.poolOrderId,
     '',
     NEW.updatedBy,
-    'Pool created.',
-    NEW.lastUpdated);
+    'Pool order created.',
+    NEW.lastUpdated)//
+
+DELIMITER ;
+-- EndNoTest

--- a/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
+++ b/sqlstore/src/main/resources/db/migration/V8001__pool_order_create_trigger.sql
@@ -1,0 +1,9 @@
+DROP TRIGGER IF EXISTS PoolOrderInsert;
+CREATE TRIGGER PoolOrderInsert AFTER INSERT ON PoolOrder
+FOR EACH ROW
+  INSERT INTO PoolOrderChangeLog(poolOrderId, columnsChanged, userId, message, changeTime) VALUES (
+    NEW.poolOrderId,
+    '',
+    NEW.updatedBy,
+    'Pool created.',
+    NEW.lastUpdated);


### PR DESCRIPTION
Since Create/Link Sequencing Orders buttons appear to be broken, change logs can be added for them when they get fixed, probably by me (GLT-2983, GLT-2984)