### PR TITLE
front-end exception handling fixup

### DIFF
--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
@@ -91,7 +91,6 @@ import uk.ac.bbsrc.tgac.miso.core.service.RunService;
 import uk.ac.bbsrc.tgac.miso.core.service.SampleClassService;
 import uk.ac.bbsrc.tgac.miso.core.service.SampleService;
 import uk.ac.bbsrc.tgac.miso.core.service.SampleValidRelationshipService;
-import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationException;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.NamingScheme;
 import uk.ac.bbsrc.tgac.miso.core.util.AliasComparator;
 import uk.ac.bbsrc.tgac.miso.core.util.AlphanumericComparator;
@@ -107,6 +106,7 @@ import uk.ac.bbsrc.tgac.miso.dto.LibraryTemplateDto;
 import uk.ac.bbsrc.tgac.miso.dto.SampleAliquotDto;
 import uk.ac.bbsrc.tgac.miso.dto.SampleAliquotSingleCellDto;
 import uk.ac.bbsrc.tgac.miso.dto.SampleDto;
+import uk.ac.bbsrc.tgac.miso.webapp.controller.component.ClientErrorException;
 import uk.ac.bbsrc.tgac.miso.webapp.util.BulkCreateTableBackend;
 import uk.ac.bbsrc.tgac.miso.webapp.util.BulkEditTableBackend;
 import uk.ac.bbsrc.tgac.miso.webapp.util.BulkPropagateTableBackend;
@@ -409,7 +409,7 @@ public class EditLibraryController {
           if (sampleClass == null) {
             sampleClass = detailed.getSampleClass();
           } else if (sampleClass.getId() != detailed.getSampleClass().getId()) {
-            throw new ValidationException("Can only create libraries when samples all have the same class.");
+            throw new ClientErrorException("Can only create libraries when samples all have the same class.");
           }
         } else {
           hasPlain = true;

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/component/ExceptionHandlerAdvice.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/component/ExceptionHandlerAdvice.java
@@ -9,10 +9,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.ModelAndView;
-import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationError;
-import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationException;
-
-import java.util.stream.Collectors;
 
 @ControllerAdvice("uk.ac.bbsrc.tgac.miso.webapp.controller")
 public class ExceptionHandlerAdvice {
@@ -27,7 +23,7 @@ public class ExceptionHandlerAdvice {
 
   @ExceptionHandler(ClientErrorException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  public ModelAndView showClientError(final ServerErrorException e) {
+  public ModelAndView showClientError(final ClientErrorException e) {
     return fromExceptionMessage("Bad Request", e, true);
   }
 
@@ -43,18 +39,6 @@ public class ExceptionHandlerAdvice {
     logException(e);
     return withMessages("Server Error",
         "An unexpected error has occurred. If the problem persists, please report it to your MISO administrators", true);
-  }
-
-  @ExceptionHandler(ValidationException.class)
-  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-  public ModelAndView showValidationErrors(final ValidationException e){
-    // A ValidationException might have >1 ValidationError. Show all their messages
-    return withMessages("Input Validation Error",
-            e.getErrors()
-              .stream()
-              .map(ValidationError::getMessage)
-              .collect(Collectors.joining("\n")),
-            true);
   }
 
   private ModelAndView fromExceptionMessage(String genericMessage, Exception e, boolean possibleBug) {


### PR DESCRIPTION
`ValidationException` should only be thrown from the service layer during save/update/delete attempts, which should only happen through `RestController`s. Also, there was a bug in showing the error page for `ClientErrorException`s