### PR TITLE
GLT-3068: improved performance of library aliquot related things

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@ Changes:
 
   * Fixed Javascript error when adding library aliquot with no indices to a pool on the Edit Pool
     page
+  * Improved performance of Worksets list page and other things affected by the library aliquot
+    child search fix in v0.2.196
 
 # 0.2.196
 
@@ -27,6 +29,8 @@ Known Issues:
 
   * When attempting to add a library aliquot with no indices to a pool on the Edit Pool page, a
     Javascript error occurs and the Library Aliquots table disappears
+  * Some functions are very slow due to the library aliquot child search fix, especially the
+    Worksets list page
 
 # 0.2.195
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAliquot.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAliquot.java
@@ -30,22 +30,18 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
@@ -64,7 +60,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.ConcentrationUnit;
 import uk.ac.bbsrc.tgac.miso.core.data.Deletable;
 import uk.ac.bbsrc.tgac.miso.core.data.HierarchyEntity;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
-import uk.ac.bbsrc.tgac.miso.core.data.Pool;
 import uk.ac.bbsrc.tgac.miso.core.data.VolumeUnit;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.boxposition.LibraryAliquotBoxPosition;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.LibraryAliquotChangeLog;
@@ -124,11 +119,6 @@ public class LibraryAliquot extends AbstractBoxable
   @ManyToOne
   @JoinColumn(name = "targetedSequencingId")
   private TargetedSequencing targetedSequencing;
-
-  @ManyToMany(targetEntity = PoolImpl.class, fetch = FetchType.EAGER)
-  @JoinTable(name = "Pool_LibraryAliquot", joinColumns = { @JoinColumn(name = "aliquotId") }, inverseJoinColumns = {
-      @JoinColumn(name = "poolId") })
-  private Set<Pool> pools;
 
   @ManyToOne(targetEntity = UserImpl.class)
   @JoinColumn(name = "lastModifier")
@@ -269,14 +259,6 @@ public class LibraryAliquot extends AbstractBoxable
   @Override
   public void setIdentificationBarcode(String identificationBarcode) {
     this.identificationBarcode = nullifyStringIfBlank(identificationBarcode);
-  }
-
-  public Set<Pool> getPools() {
-    return pools;
-  }
-
-  public void setPools(Set<Pool> pools) {
-    this.pools = pools;
   }
 
   @Override

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAliquotService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAliquotService.java
@@ -33,6 +33,7 @@ import uk.ac.bbsrc.tgac.miso.core.service.BoxService;
 import uk.ac.bbsrc.tgac.miso.core.service.LibraryAliquotService;
 import uk.ac.bbsrc.tgac.miso.core.service.LibraryDesignCodeService;
 import uk.ac.bbsrc.tgac.miso.core.service.LibraryService;
+import uk.ac.bbsrc.tgac.miso.core.service.PoolService;
 import uk.ac.bbsrc.tgac.miso.core.service.TargetedSequencingService;
 import uk.ac.bbsrc.tgac.miso.core.service.WorksetService;
 import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationError;
@@ -43,6 +44,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.DeletionStore;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.core.util.PaginatedDataSource;
 import uk.ac.bbsrc.tgac.miso.core.util.PaginationFilter;
+import uk.ac.bbsrc.tgac.miso.core.util.Pluralizer;
 import uk.ac.bbsrc.tgac.miso.persistence.LibraryAliquotStore;
 import uk.ac.bbsrc.tgac.miso.persistence.LibraryStore;
 
@@ -65,6 +67,8 @@ public class DefaultLibraryAliquotService
   private LibraryDesignCodeService libraryDesignCodeService;
   @Autowired
   private TargetedSequencingService targetedSequencingService;
+  @Autowired
+  private PoolService poolService;
   @Autowired
   private BoxService boxService;
   @Autowired
@@ -359,12 +363,13 @@ public class DefaultLibraryAliquotService
   }
 
   @Override
-  public ValidationResult validateDeletion(LibraryAliquot object) {
+  public ValidationResult validateDeletion(LibraryAliquot object) throws IOException {
     ValidationResult result = new ValidationResult();
 
-    if (object.getPools() != null && !object.getPools().isEmpty()) {
-      result.addError(new ValidationError(object.getName() + " is included in " + object.getPools().size() + " pool"
-          + (object.getPools().size() > 1 ? "s" : "")));
+    int poolCount = poolService.listByLibraryAliquotId(object.getId()).size();
+    if (poolCount > 0) {
+      result.addError(
+          new ValidationError(String.format("%s is included in %d %s", object.getName(), poolCount, Pluralizer.pools(poolCount))));
     }
 
     return result;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryAliquotDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryAliquotDaoTest.java
@@ -315,6 +315,11 @@ public class HibernateLibraryAliquotDaoTest extends AbstractDAOTest {
     testSearch(PaginationFilter.freezer("freezer1"));
   }
 
+  @Test
+  public void testSearchByPool() throws Exception {
+    testSearch(PaginationFilter.pool(1L));
+  }
+
   /**
    * Verifies Hibernate mappings by ensuring that no exception is thrown by a search
    * 

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolDaoTest.java
@@ -255,6 +255,11 @@ public class HibernatePoolDaoTest extends AbstractDAOTest {
   }
 
   @Test
+  public void testListByLibraryAliquotId() throws Exception {
+    assertEquals(2, dao.listByLibraryAliquotId(1L).size());
+  }
+
+  @Test
   public void testListByProjectId() throws IOException {
     assertEquals(10, dao.listByProjectId(1L).size());
   }


### PR DESCRIPTION
Previous problem was caused by attempting to lazy load `LibraryAliquot.pools`. Switching to eager loading caused slowness. Fixed by removing the pools collection entirely and retrieving from the `PoolService` only when needed