### PR TITLE
fixed version number shown in page footer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ Changes:
 
   * Fixed Javascript error when adding library aliquot with no indices to a pool on the Edit Pool
     page
+  * Fixed issue where wrong MISO version was sometimes shown in the page footer
 
 # 0.2.196
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/TagUtils.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/TagUtils.java
@@ -60,4 +60,8 @@ public class TagUtils {
     }
   }
 
+  public static String version() {
+    return Version.VERSION;
+  }
+
 }

--- a/miso-web/src/main/webapp/WEB-INF/footer.jsp
+++ b/miso-web/src/main/webapp/WEB-INF/footer.jsp
@@ -20,7 +20,8 @@
   ~
   ~ **********************************************************************
   --%>
-<%@ page import="uk.ac.bbsrc.tgac.miso.Version" %>
+<%@ taglib prefix="miso" uri="http://miso.tgac.bbsrc.ac.uk/tags/form" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 </div>
 <div id="footer">
@@ -29,7 +30,7 @@
     <p>
         &copy; 2010 - <fmt:formatDate value="${timestamp}" pattern="yyyy"/>
         <a href="https://github.com/miso-lims/miso-lims">MISO LIMS</a> | Version:
-        <%=Version.VERSION%>
+        ${miso:version()}
     </p>
 </div>
 </body>

--- a/miso-web/src/main/webapp/WEB-INF/header.jsp
+++ b/miso-web/src/main/webapp/WEB-INF/header.jsp
@@ -22,7 +22,6 @@
   --%>
 
 <%@ page import="uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider" %>
-<%@ page import="uk.ac.bbsrc.tgac.miso.Version" %>
 <!DOCTYPE html>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -89,7 +88,7 @@
   <!-- concatenated MISO stylesheets and scripts -->
   <link rel="stylesheet" href="<c:url value='/styles/style.css'/>" type="text/css">
   <script type="text/javascript" src="<c:url value='/miso/constants.js'/>?ts=<fmt:formatNumber value="${timestamp.time / 60000}" maxFractionDigits="0" groupingUsed="false" />"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/header_script.js'/>?version=<%=Version.VERSION%>"></script>
+  <script type="text/javascript" src="<c:url value='/scripts/header_script.js'/>?version=${miso:version()}"></script>
 
 
   <link rel="shortcut icon" href="<c:url value='/styles/images/favicon.ico'/>" type="image/x-icon"/>

--- a/miso-web/src/main/webapp/WEB-INF/miso-form.tld
+++ b/miso-web/src/main/webapp/WEB-INF/miso-form.tld
@@ -426,6 +426,12 @@
         <function-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.TagUtils</function-class>
         <function-signature>String docsVersion()</function-signature>
     </function>
+    
+    <function>
+        <name>version</name>
+        <function-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.TagUtils</function-class>
+        <function-signature>String version()</function-signature>
+    </function>
 
 
 </taglib>


### PR DESCRIPTION
I don't have an explanation as to why, but `<%=Version.VERSION%>` was sometimes returning the version from a previous build, whereas the one generated via a `TagUtils` method for the docs version was always correct, so I changed the other uses of version to go through `TagUtils` too :man_shrugging: 