### PR TITLE
LDAP Compatibility Fix

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/LDAPSecurityManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/LDAPSecurityManager.java
@@ -52,13 +52,12 @@ public class LDAPSecurityManager implements SecurityManager {
 
   @Override
   public void syncUser(UserDetails userDetails) throws IOException {
-    InetOrgPerson person = (InetOrgPerson) userDetails;
-    User u = LimsSecurityUtils.fromLdapUser(person);
+    User u = LimsSecurityUtils.fromLdapUser(userDetails);
     User dbu = userService.getByLoginName(u.getLoginName());
     if (dbu == null || !dbu.equals(u)) {
       userService.create(u);
     } else {
-      LimsSecurityUtils.updateFromLdapUser(dbu, person);
+      LimsSecurityUtils.updateFromLdapUser(dbu, userDetails);
       userService.update(dbu);
     }
   }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/util/LimsSecurityUtils.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/util/LimsSecurityUtils.java
@@ -93,6 +93,8 @@ public class LimsSecurityUtils {
       InetOrgPerson person = (InetOrgPerson) ldapUserDetails;
       target.setFullName(person.getDisplayName());
       target.setEmail(person.getMail());
+    } else {
+      target.setFullName(ldapUserDetails.getUsername());
     }
   }
 


### PR DESCRIPTION
There appears to be no guarantee that the implementation of UserDetails we get will be an InetOrgPerson (external user seeing LdapUserDetailsImpl instead). The only methods we use outside of the interface are the Display Name and Email getters, so only use those if instanceof InetOrgPerson.

Still setting up LDAP Server locally to test against, but requesting thoughts on this approach to ensure there aren't obvious pitfalls