### PR TITLE
GLT-3270: fixed scientific name required

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@ Changes:
   * Fixed Receipt Confirmed and Receipt QC Passed validation on Create Samples page
   * Fixed Fill Boxes actions on the bulk Create/Edit Sample and Library Aliquot pages
   * Fixed library receipt creating multiple ltransfers
+  * Fixed scientific name to show as required on bulk sample pages
+  * Fixed scientific name on bulk sample pages to use default value from project or config
 
 Upgrade Notes:
 
@@ -43,6 +45,8 @@ Changes:
 
 Known Issues:
 
+  * Scientific name is required, but not shown as required on bulk sample pages
+  * Default scientific name from project or config is not used on bulk sample pages
   * Edit button on Scientific Names list links to Edit Run Purposes page instead of Edit Scientific
     Names
   * Receipt Confirmed and Receipt QC Passed fields do not validate on Create Samples page when cleared

--- a/miso-web/src/main/webapp/scripts/bulk_sample.js
+++ b/miso-web/src/main/webapp/scripts/bulk_sample.js
@@ -425,6 +425,7 @@ BulkTarget.sample = (function($) {
         title: 'Sci. Name',
         type: 'dropdown',
         data: 'scientificNameId',
+        required: true,
         source: Constants.scientificNames,
         sortSource: Utils.sorting.standardSort('alias'),
         getItemLabel: Utils.array.getAlias,


### PR DESCRIPTION
Replaces previous PR. This just fixes the required field as other changes already merged into develop have fixed the default values