### PR TITLE
GLT-3290: fixed library aliquot location showing barcode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Changes:
 
-
+  * Fixed library aliquot "Location" column showing barcode in some cases
 
 # 1.8.1
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAliquot.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAliquot.java
@@ -380,7 +380,7 @@ public class LibraryAliquot extends AbstractBoxable
 
   @Override
   public String getLocationBarcode() {
-    return identificationBarcode;
+    return null;
   }
 
   @Override

--- a/miso-web/src/main/webapp/styles/style-full.css
+++ b/miso-web/src/main/webapp/styles/style-full.css
@@ -1,8 +1,8 @@
 :root {
     --grey-dark: #A9A9A9;
     --grey-light: #CDCDCD;
-    --purple-dark: var(--purple-dark);
-    --purple-light: var(--purple-light);
+    --purple-dark: #404087;
+    --purple-light: #F0F0FF;
 }
 
 html {


### PR DESCRIPTION
Also, _someone_ clearly used replace all in the css file 🤦‍♂️ 