### PR TITLE
GLT-3291: fixed creating stock sample classes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 Changes:
 
   * Fixed library aliquot "Location" column showing barcode in some cases
+  * Fixed error creating stock sample classes (detailed sample)
 
 # 1.8.1
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleClassService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleClassService.java
@@ -234,7 +234,7 @@ public class DefaultSampleClassService extends AbstractSaveService<SampleClass> 
       break;
     case SampleStock.CATEGORY_NAME:
       allowedParents = Sets.newHashSet(SampleTissue.CATEGORY_NAME, SampleTissueProcessing.CATEGORY_NAME, SampleStock.CATEGORY_NAME);
-      if (SampleStockSingleCell.SUBCATEGORY_NAME.contentEquals(sampleClass.getSampleSubcategory())) {
+      if (SampleStockSingleCell.SUBCATEGORY_NAME.equals(sampleClass.getSampleSubcategory())) {
         // Single Cell Stocks need to be parented to a Single Cell (tissue processing) class instead of a tissue class
         if (sampleClass.getParentRelationships().stream()
             .filter(relationship -> SampleTissueProcessing.CATEGORY_NAME.equals(relationship.getParent().getSampleCategory())


### PR DESCRIPTION
Eclipse likes turning my `.equals` into `.contentEquals`, `.stream` into `.parallelStream`, etc... Looks like it's related to a bug that goes back to 2016... 🎉 https://bugs.eclipse.org/bugs/show_bug.cgi?id=506804