### PR TITLE
updated recommendations for migration error work-arounds

### DIFF
--- a/docs/admin/baremetal-installation-guide.md
+++ b/docs/admin/baremetal-installation-guide.md
@@ -16,7 +16,7 @@ Application Server:
 
 Database Server:
 
-* MySQL 5.7.7 or MariaDB 10.2
+* MySQL 5.7.7 or MariaDB 10.2.3
 * [Flyway 5.2.4](https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/5.2.4/) (newer versions may cause issues)
 
 Development Machine(s):
@@ -250,102 +250,8 @@ and replacing `zeroDateTimeBehavior=convertToNull` with `zeroDateTimeBehavior=CO
 jdbc:mysql://localhost:3306/lims?autoReconnect=true&zeroDateTimeBehavior=CONVERT_TO_NULL&useUnicode=true&characterEncoding=UTF-8&useLegacyDatetimeCode=false
 ```
 
-### If you have run into an issue with migration `V0320` with MariaDB:
+If you run into an issue with migration `V0611`, ensure that the user running Flyway has read and write permissions on
+`MISO_FILES_DIR`.
 
-This migration contains some syntax which is not compatible with MariaDB. You can skip over the `Printer` code at issue, and manually copy the remainder of the migration into the MySQL console (as seen below). The last command changes the Flyway state from failed to succeeded. You can then run Flyway again from the terminal and it will resume with the next migration.
-
-```
-CREATE TABLE PlatformSizes (
-  platform_platformId bigint(20) NOT NULL,
-  partitionSize int NOT NULL,
-  PRIMARY KEY (platform_platformId, partitionSize),
-  CONSTRAINT fk_platform_size_platform FOREIGN KEY (platform_platformId) REFERENCES Platform (platformId)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-INSERT INTO PlatformSizes(platform_platformId, partitionSize)
-  SELECT DISTINCT platform, COUNT(*) AS c FROM SequencerPartitionContainer JOIN SequencerPartitionContainer_Partition ON containerId = container_containerId GROUP BY containerId
-  UNION SELECT platformId, 1 FROM Platform WHERE name = 'ILLUMINA' AND instrumentModel LIKE '%MiSeq%'
-  UNION SELECT platformId, 2 FROM Platform WHERE name = 'ILLUMINA' AND instrumentModel LIKE '%HiSeq%'
-  UNION SELECT platformId, 8 FROM Platform WHERE name = 'ILLUMINA' AND instrumentModel LIKE '%HiSeq%'
-  UNION SELECT platformId, 4 FROM Platform WHERE name = 'ILLUMINA' AND instrumentModel LIKE '%NextSeq%'
-  UNION SELECT platformId, 4 FROM Platform WHERE name = 'ILLUMINA' AND instrumentModel LIKE '%Genome Analyzer%'
-  UNION SELECT platformId, 1 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 2 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 3 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 4 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 5 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 6 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 7 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 8 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 9 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 10 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 11 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 12 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 13 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 14 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 15 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 16 FROM Platform WHERE name = 'PACBIO'
-  UNION SELECT platformId, 1 FROM Platform WHERE name = 'LS454'
-  UNION SELECT platformId, 2 FROM Platform WHERE name = 'LS454'
-  UNION SELECT platformId, 4 FROM Platform WHERE name = 'LS454'
-  UNION SELECT platformId, 8 FROM Platform WHERE name = 'LS454'
-  UNION SELECT platformId, 16 FROM Platform WHERE name = 'LS454'
-  UNION SELECT platformId, 6 FROM Platform WHERE name = 'SOLID' AND instrumentModel = 'AB SOLiD 5500xl'
-  UNION SELECT platformId, 1 FROM Platform WHERE name = 'SOLID' AND instrumentModel <> 'AB SOLiD 5500xl'
-  UNION SELECT platformId, 2 FROM Platform WHERE name = 'SOLID' AND instrumentModel <> 'AB SOLiD 5500xl'
-  UNION SELECT platformId, 4 FROM Platform WHERE name = 'SOLID' AND instrumentModel <> 'AB SOLiD 5500xl'
-  UNION SELECT platformId, 8 FROM Platform WHERE name = 'SOLID' AND instrumentModel <> 'AB SOLiD 5500xl'
-  UNION SELECT platformId, 16 FROM Platform WHERE name = 'SOLID' AND instrumentModel <> 'AB SOLiD 5500xl'
-;
-
-CREATE TABLE PartitionQCType (
-  partitionQcTypeId bigint(20) NOT NULL AUTO_INCREMENT,
-  description varchar(255) NOT NULL,
-  noteRequired boolean DEFAULT false,
-  PRIMARY KEY (partitionQcTypeId),
-  UNIQUE KEY uk_partitionqctype_description (description)
-) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8;
-
-CREATE TABLE Run_Partition_QC (
-  runId bigint(20) NOT NULL,
-  partitionId bigint(20) NOT NULL,
-  partitionQcTypeId bigint(20) NOT NULL,
-  notes varchar(1024),
-  PRIMARY KEY(runId, partitionId),
-  CONSTRAINT fk_rpq_run_runId FOREIGN KEY (runId) REFERENCES Run (runId),
-  CONSTRAINT fk_rpq_partition_partitionId FOREIGN KEY (partitionId) REFERENCES _Partition (partitionId),
-  CONSTRAINT fk_rpq_partitiontypeqc_partitiontypeqc FOREIGN KEY (partitionQcTypeId) REFERENCES PartitionQCType (partitionQcTypeId)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-INSERT INTO PartitionQCType(description, noteRequired) VALUES
-  ('OK', false),
-  ('OK\'d by collaborator', false),
-  ('Failed: Instrument problem', false),
-  ('Failed: Library preparation problem', false),
-  ('Failed: Analysis problem', false),
-  ('Failed: Other problem', true);
-INSERT INTO PartitionQCType(description, noteRequired)
-    SELECT CONCAT('Failed: ', name), true FROM QCType WHERE qcTarget = 'Run';
-INSERT INTO Run_Partition_QC(runId, partitionId, partitionQcTypeId, notes)
-  SELECT RunQC.run_runId, RunQC_Partition.partition_partitionId, partitionQcTypeId, information
-  FROM RunQC
-    JOIN RunQC_Partition ON RunQC.qcId = RunQC_Partition.runQc_runQcId
-    JOIN QCType ON RunQC.qcMethod = QCType.qcTypeId
-    JOIN PartitionQCType ON PartitionQCType.description = CONCAT('Failed :', QCType.name);
-DROP TABLE RunQC_Partition;
-DROP TABLE RunQC;
-DELETE FROM QCType WHERE qcTarget = 'Run';
-
-
-UPDATE flyway_schema_history SET success = 1 WHERE version = '0320';
-```
-### If you have run into an issue with migration `V0611`:
-
-Ths command changes the Flyway state from failed to succeeded. You can then run Flyway again from the terminal and it will resume with the next migration.
-
-    UPDATE flyway_schema_history SET success = 1 WHERE version = '0611';
-
-
-
-If you encounter other errors migrating the database, make sure that you are using the recommended version of Flyway (see
-[Prerequisites](#prerequisites)).
+If you encounter other errors migrating the database, make sure that you are using the recommended version of Flyway
+(see [Prerequisites](#prerequisites)).


### PR DESCRIPTION
* MariaDB 10.2.3 adds the JSON functions used in V0320
* The only issue I've found reported for V0611 is permission-related, and advising users to ignore and skip the migration could result in attachments being lost/orphaned (In #1669)