### PR TITLE
GLT-3310: fixed inconsistent sorting in paginated lists

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ Changes:
   * Fixed errors with tissue processing classes with no subcategory
   * Fixed library design code, selection, and strategy not always being selected correctly when choosing a
     library template
+  * Fixed an issue that could cause inconsistent sorting on list pages (affected Library Templates and
+    possibly other pages)
 
 # 1.10.1
 

--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -597,6 +597,7 @@
                 <miso.it.mysql.pw>${mysql.pw}</miso.it.mysql.pw>
               </systemPropertyVariables>
               <skipTests>${skipITs}</skipTests>
+              <trimStackTrace>false</trimStackTrace>
               <excludes>
                 <exclude>**/PlainSampleITs.java</exclude>
               </excludes>
@@ -839,6 +840,7 @@
                 <miso.it.mysql.pw>${mysql.pw}</miso.it.mysql.pw>
               </systemPropertyVariables>
               <skipITs>false</skipITs>
+              <trimStackTrace>false</trimStackTrace>
               <excludes>
                 <exclude>**/*IT.java</exclude>
               </excludes>

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -68,22 +68,6 @@ var Utils = Utils
         return values;
       },
 
-      setSortFromPriority: function(table) {
-        var info = table.aoColumns.reduce(function(acc, curr, index) {
-          return !curr.hasOwnProperty('iSortPriority') || acc.iSortPriority > curr.iSortPriority ? acc : {
-            iSortPriority: curr.iSortPriority,
-            bSortDirection: !!curr.bSortDirection,
-            iPos: index
-          };
-        }, {
-          iSortPriority: -1
-        })
-        if (info.iSortPriority > -1) {
-          table.aaSorting = [[info.iPos, info.bSortDirection ? "asc" : "desc"]];
-        }
-        return table;
-      },
-
       checkCommonSampleClasses: function(jqueryDataTableData, getSampleClassFromObject, selectedIdsArray, errorText) {
         var sampleClasses = jqueryDataTableData.aaData.filter(function(x) {
           return selectedIdsArray.indexOf(x.id) != -1;

--- a/miso-web/src/main/webapp/scripts/list.js
+++ b/miso-web/src/main/webapp/scripts/list.js
@@ -273,6 +273,22 @@ ListUtils = (function($) {
         $('<p>').attr('id', 'headerMessage').addClass('big big-' + (level || 'info')).css('margin-top', '.25em').text(text));
   };
 
+  var setSortFromPriority = function(table) {
+    var info = table.aoColumns.reduce(function(acc, curr, index) {
+      return !curr.hasOwnProperty('iSortPriority') || acc.iSortPriority > curr.iSortPriority ? acc : {
+        iSortPriority: curr.iSortPriority,
+        bSortDirection: !!curr.bSortDirection,
+        iPos: index
+      };
+    }, {
+      iSortPriority: 0
+    })
+    if (info.iSortPriority > 0) { // Note: if unspecified, table defaults to sorting by column 0 ascending
+      table.aaSorting = [[info.iPos, info.bSortDirection ? "asc" : "desc"]];
+    }
+    return table;
+  };
+
   var initTable = function(elementId, target, projectId, config, optionModifier, selectAll) {
     var staticActions = target.createStaticActions(config, projectId);
     var bulkActions = target.createBulkActions(config, projectId);
@@ -429,7 +445,7 @@ ListUtils = (function($) {
       }
     }
     var errorMessage = document.createElement('DIV');
-    var options = Utils.setSortFromPriority({
+    var options = setSortFromPriority({
       'aoColumns': columns,
       'aLengthMenu': [10, 25, 50, 100, 200, 400, 1000],
       'bJQueryUI': true,

--- a/miso-web/src/main/webapp/scripts/list_library_template.js
+++ b/miso-web/src/main/webapp/scripts/list_library_template.js
@@ -147,7 +147,7 @@ ListTarget.library_template = {
     }
 
     return [
-        ListUtils.labelHyperlinkColumn('Alias', Urls.ui.libraryTemplates.edit, Utils.array.getId, 'alias', 0, true),
+        ListUtils.labelHyperlinkColumn('Alias', Urls.ui.libraryTemplates.edit, Utils.array.getId, 'alias', 1, true),
         {
           "sTitle": "Library Design",
           "mData": "designId",

--- a/sqlstore/pom.xml
+++ b/sqlstore/pom.xml
@@ -386,6 +386,7 @@
                 <miso.it.mysql.pw>${mysql.pw}</miso.it.mysql.pw>
               </systemPropertyVariables>
               <skipTests>${skipITs}</skipTests>
+              <trimStackTrace>false</trimStackTrace>
             </configuration>
           </plugin>
         </plugins>

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateArrayDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateArrayDao.java
@@ -178,11 +178,6 @@ public class HibernateArrayDao implements ArrayStore, HibernatePaginatedDataSour
   }
 
   @Override
-  public String propertyForId() {
-    return "id";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     if ("arrayModelId".equals(original)) {
       return "arrayModel.id";

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateArrayRunDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateArrayRunDao.java
@@ -145,11 +145,6 @@ public class HibernateArrayRunDao implements ArrayRunStore, HibernatePaginatedDa
   }
 
   @Override
-  public String propertyForId() {
-    return "id";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     if ("platformType".equals(original)) return "instrumentModel.platformType";
     if ("status".equals(original)) return "health";

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBoxDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBoxDao.java
@@ -320,11 +320,6 @@ public class HibernateBoxDao implements BoxStore, HibernatePaginatedDataSource<B
   }
 
   @Override
-  public String propertyForId() {
-    return "boxId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     switch (original) {
     case "sizeId":

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateDeletionDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateDeletionDao.java
@@ -63,11 +63,6 @@ public class HibernateDeletionDao implements DeletionStore, HibernatePaginatedDa
   }
 
   @Override
-  public String propertyForId() {
-    return "id";
-  }
-
-  @Override
   public String[] getSearchProperties() {
     return SEARCH_PROPERTIES;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIndexDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIndexDao.java
@@ -79,11 +79,6 @@ public class HibernateIndexDao extends HibernateSaveDao<Index> implements IndexS
   }
 
   @Override
-  public String propertyForId() {
-    return "indexId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstrumentDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstrumentDao.java
@@ -157,11 +157,6 @@ public class HibernateInstrumentDao implements InstrumentStore, HibernatePaginat
   }
 
   @Override
-  public String propertyForId() {
-    return "id";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     switch (original) {
     case "platformType":

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstrumentModelDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstrumentModelDao.java
@@ -162,11 +162,6 @@ public class HibernateInstrumentModelDao extends HibernateSaveDao<InstrumentMode
   }
 
   @Override
-  public String propertyForId() {
-    return "instrumentModelId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDao.java
@@ -217,11 +217,6 @@ public class HibernateKitDao implements KitStore, HibernatePaginatedDataSource<K
   }
 
   @Override
-  public String propertyForId() {
-    return "kitDescriptorId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryAliquotDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryAliquotDao.java
@@ -182,11 +182,6 @@ public class HibernateLibraryAliquotDao
   }
 
   @Override
-  public String propertyForId() {
-    return "aliquotId";
-  }
-
-  @Override
   public String propertyForUser(boolean creator) {
     return creator ? "creator" : "lastModifier";
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDao.java
@@ -13,7 +13,13 @@ import java.util.function.Consumer;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.criterion.*;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.MatchMode;
+import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Property;
+import org.hibernate.criterion.Restrictions;
 import org.hibernate.sql.JoinType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -371,11 +377,6 @@ public class HibernateLibraryDao implements LibraryStore, HibernatePaginatedBoxa
     default:
       return null;
     }
-  }
-
-  @Override
-  public String propertyForId() {
-    return "libraryId";
   }
 
   @Override

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryTemplateDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryTemplateDao.java
@@ -90,11 +90,6 @@ public class HibernateLibraryTemplateDao implements LibraryTemplateStore, Hibern
   }
 
   @Override
-  public String propertyForId() {
-    return "libraryTemplateId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListContainerViewDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListContainerViewDao.java
@@ -76,11 +76,6 @@ public class HibernateListContainerViewDao implements ListContainerViewDao, Hibe
   }
 
   @Override
-  public String propertyForId() {
-    return "containerId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListPoolViewDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListPoolViewDao.java
@@ -88,11 +88,6 @@ public class HibernateListPoolViewDao implements ListPoolViewDao, HibernatePagin
   }
 
   @Override
-  public String propertyForId() {
-    return "poolId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     if ("creationDate".equals(original)) {
       return "creationTime";

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListTransferViewDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListTransferViewDao.java
@@ -73,11 +73,6 @@ public class HibernateListTransferViewDao implements ListTransferViewDao, Hibern
   }
 
   @Override
-  public String propertyForId() {
-    return "transferId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListWorksetViewDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateListWorksetViewDao.java
@@ -73,11 +73,6 @@ public class HibernateListWorksetViewDao implements ListWorksetViewStore, Hibern
   }
 
   @Override
-  public String propertyForId() {
-    return "worksetId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePaginatedDataSource.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePaginatedDataSource.java
@@ -102,7 +102,7 @@ public interface HibernatePaginatedDataSource<T> extends PaginatedDataSource<T>,
     }
 
     Criteria idCriteria = null;
-    if (filters.length == 0 && !sortProperty.contains(".")) {
+    if (filters.length == 0 && (sortProperty == null || !sortProperty.contains("."))) {
       // Faster method
       ProjectionList projections = Projections.projectionList().add(Projections.property("id"));
       if (primaryOrder != null) {
@@ -152,7 +152,10 @@ public interface HibernatePaginatedDataSource<T> extends PaginatedDataSource<T>,
     }
     // We do this in two steps to make a smaller query that that the database can optimise
     Criteria criteria = createPaginationCriteria();
-    criteria.addOrder(primaryOrder);
+    if (primaryOrder != null) {
+      criteria.addOrder(primaryOrder);
+    }
+    criteria.addOrder(idOrder);
     criteria.add(Restrictions.in("id", ids));
 
     @SuppressWarnings("unchecked")

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePaginatedDataSource.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePaginatedDataSource.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import javax.persistence.Table;
 
@@ -18,6 +19,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Order;
+import org.hibernate.criterion.ProjectionList;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.sql.JoinType;
@@ -94,21 +96,36 @@ public interface HibernatePaginatedDataSource<T> extends PaginatedDataSource<T>,
 
     if (offset < 0 || limit < 0) throw new IOException("Limit and Offset must not be less than zero");
     String sortProperty = propertyForSortColumn(sortCol);
-    Order order = sortDir ? Order.asc(sortProperty) : Order.desc(sortProperty);
+    Order primaryOrder = null;
+    if (sortProperty != null && !"id".equals(sortProperty)) {
+      primaryOrder = sortDir ? Order.asc(sortProperty) : Order.desc(sortProperty);
+    }
 
     Criteria idCriteria = null;
     if (filters.length == 0 && !sortProperty.contains(".")) {
       // Faster method
-      idCriteria = currentSession().createCriteria(getRealClass())
-          .setProjection(Projections.projectionList().add(Projections.property("id")).add(Projections.property(sortProperty)));
+      ProjectionList projections = Projections.projectionList().add(Projections.property("id"));
+      if (primaryOrder != null) {
+        projections.add(Projections.property(sortProperty));
+      }
+      idCriteria = currentSession().createCriteria(getRealClass()).setProjection(projections);
     } else {
       // We need to keep both the id column and the sort column in the result set for the database to provide us with sorted, duplicate-free
       // results. We will throw the sort property out later.
-      idCriteria = createPaginationCriteria()
-          .setProjection(Projections.projectionList().add(Projections.groupProperty("id")).add(Projections.groupProperty(sortProperty)));
+      ProjectionList projections = Projections.projectionList().add(Projections.groupProperty("id"));
+      if (primaryOrder != null) {
+        projections.add(Projections.groupProperty(sortProperty));
+      }
+      idCriteria = createPaginationCriteria().setProjection(projections);
     }
 
-    idCriteria.addOrder(order);
+    if (primaryOrder != null) {
+      idCriteria.addOrder(primaryOrder);
+    }
+
+    // Always add second sort by IDs to ensure consistent order between pages (primary sort may not be deterministic)
+    Order idOrder = sortDir ? Order.asc("id") : Order.desc("id");
+    idCriteria.addOrder(idOrder);
 
     for (PaginationFilter filter : filters) {
       filter.apply(this, idCriteria, errorHandler);
@@ -119,15 +136,24 @@ public interface HibernatePaginatedDataSource<T> extends PaginatedDataSource<T>,
       idCriteria.setMaxResults(limit);
     }
 
-    @SuppressWarnings("unchecked")
-    List<Object[]> ids = idCriteria.list();
+    // IDs are usually Longs, but could be composite ID classes, or something else
+    List<Object> ids;
+    if (primaryOrder == null) {
+      @SuppressWarnings("unchecked")
+      List<Object> idResults = idCriteria.list();
+      ids = idResults;
+    } else {
+      @SuppressWarnings("unchecked")
+      List<Object[]> idResults = idCriteria.list();
+      ids = idResults.stream().map(x -> x[0]).collect(Collectors.toList());
+    }
     if (ids.isEmpty()) {
       return Collections.emptyList();
     }
     // We do this in two steps to make a smaller query that that the database can optimise
     Criteria criteria = createPaginationCriteria();
-    criteria.addOrder(order);
-    criteria.add(Restrictions.in("id", ids.stream().map(x -> x[0]).toArray()));
+    criteria.addOrder(primaryOrder);
+    criteria.add(Restrictions.in("id", ids));
 
     @SuppressWarnings("unchecked")
     List<T> records = criteria.list();
@@ -146,13 +172,6 @@ public interface HibernatePaginatedDataSource<T> extends PaginatedDataSource<T>,
    */
 
   public abstract String propertyForDate(Criteria criteria, DateType type);
-
-  /**
-   * The property name for the ID field
-   * 
-   * @return the name of the property, or null if search by ID shouldn't be allowed
-   */
-  public abstract String propertyForId();
 
   /**
    * Determine the correct Hibernate property given the user-supplied sort column.
@@ -249,22 +268,12 @@ public interface HibernatePaginatedDataSource<T> extends PaginatedDataSource<T>,
 
   @Override
   public default void restrictPaginationById(Criteria criteria, long id, Consumer<String> errorHandler) {
-    String property = propertyForId();
-    if (property == null) {
-      errorHandler.accept(String.format("%s cannot be filtered by ID", getFriendlyName()));
-    } else {
-      criteria.add(Restrictions.eq(property, id));
-    }
+    criteria.add(Restrictions.eq("id", id));
   }
 
   @Override
-  default void restrictPaginationByIds(Criteria criteria, List<Long> ids, Consumer<String> errorHandler) {
-    String property = propertyForId();
-    if (property == null) {
-      errorHandler.accept(String.format("%s cannot be filtered by ID", getFriendlyName()));
-    } else {
-      criteria.add(Restrictions.in("id", ids));
-    }
+  public default void restrictPaginationByIds(Criteria criteria, List<Long> ids, Consumer<String> errorHandler) {
+    criteria.add(Restrictions.in("id", ids));
   }
 
   @Override

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePaginatedDataSource.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePaginatedDataSource.java
@@ -119,12 +119,14 @@ public interface HibernatePaginatedDataSource<T> extends PaginatedDataSource<T>,
       idCriteria = createPaginationCriteria().setProjection(projections);
     }
 
+    Order idOrder = null;
     if (primaryOrder != null) {
       idCriteria.addOrder(primaryOrder);
+      idOrder = Order.asc("id");
+    } else {
+      idOrder = sortDir ? Order.asc("id") : Order.desc("id");
     }
-
     // Always add second sort by IDs to ensure consistent order between pages (primary sort may not be deterministic)
-    Order idOrder = sortDir ? Order.asc("id") : Order.desc("id");
     idCriteria.addOrder(idOrder);
 
     for (PaginationFilter filter : filters) {

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolDao.java
@@ -260,11 +260,6 @@ public class HibernatePoolDao implements PoolStore, HibernatePaginatedBoxableSou
   }
 
   @Override
-  public String propertyForId() {
-    return "poolId";
-  }
-
-  @Override
   public String propertyForUser(boolean creator) {
     return creator ? "creator" : "lastModifier";
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderDao.java
@@ -69,11 +69,6 @@ public class HibernatePoolOrderDao extends HibernateSaveDao<PoolOrder> implement
   }
 
   @Override
-  public String propertyForId() {
-    return "poolOrderId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     switch (original) {
     case "purposeAlias":

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolableElementViewDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolableElementViewDao.java
@@ -10,7 +10,11 @@ import java.util.function.Consumer;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.criterion.*;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.MatchMode;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Property;
+import org.hibernate.criterion.Restrictions;
 import org.hibernate.sql.JoinType;
 import org.hibernate.type.LongType;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -174,11 +178,6 @@ public class HibernatePoolableElementViewDao implements PoolableElementViewDao, 
     default:
       return null;
     }
-  }
-
-  @Override
-  public String propertyForId() {
-    return "aliquotId";
   }
 
   @Override

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePrinterDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePrinterDao.java
@@ -105,11 +105,6 @@ public class HibernatePrinterDao implements PrinterStore, HibernatePaginatedData
   }
 
   @Override
-  public String propertyForId() {
-    return "printerId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     switch (original) {
     case "available":

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunDao.java
@@ -279,11 +279,6 @@ public class HibernateRunDao implements RunStore, HibernatePaginatedDataSource<R
   }
 
   @Override
-  public String propertyForId() {
-    return "runId";
-  }
-
-  @Override
   public String propertyForUser(boolean creator) {
     return creator ? "creator" : "lastModifier";
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
@@ -30,8 +30,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import uk.ac.bbsrc.tgac.miso.core.data.*;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.*;
+import uk.ac.bbsrc.tgac.miso.core.data.Array;
+import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
+import uk.ac.bbsrc.tgac.miso.core.data.Sample;
+import uk.ac.bbsrc.tgac.miso.core.data.SampleIdentity;
+import uk.ac.bbsrc.tgac.miso.core.data.SampleTissue;
+import uk.ac.bbsrc.tgac.miso.core.data.Workset;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.DetailedSampleImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleIdentityImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleTissueImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.view.EntityReference;
 import uk.ac.bbsrc.tgac.miso.core.util.DateType;
 import uk.ac.bbsrc.tgac.miso.persistence.BoxStore;
@@ -349,11 +357,6 @@ public class HibernateSampleDao implements SampleStore, HibernatePaginatedBoxabl
   }
 
   @Override
-  public String propertyForId() {
-    return "sampleId";
-  }
-
-  @Override
   public String propertyForUser(boolean creator) {
     return creator ? "creator" : "lastModifier";
   }
@@ -439,6 +442,7 @@ public class HibernateSampleDao implements SampleStore, HibernatePaginatedBoxabl
         .uniqueResult();
   }
 
+  @Override
   public void restrictPaginationByWorksetId(Criteria criteria, long worksetId, Consumer<String> errorHandler) {
     DetachedCriteria subquery = DetachedCriteria.forClass(Workset.class)
             .createAlias("samples", "sample")

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencingOrderCompletionDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencingOrderCompletionDao.java
@@ -97,8 +97,13 @@ public class HibernateSequencingOrderCompletionDao implements SequencingOrderCom
   }
 
   @Override
-  public String propertyForId() {
-    return null;
+  public void restrictPaginationById(Criteria criteria, long id, Consumer<String> errorHandler) {
+    errorHandler.accept(String.format("%s cannot be filtered by ID", getFriendlyName()));
+  }
+
+  @Override
+  public void restrictPaginationByIds(Criteria criteria, List<Long> ids, Consumer<String> errorHandler) {
+    errorHandler.accept(String.format("%s cannot be filtered by ID", getFriendlyName()));
   }
 
   @Override

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSopDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSopDao.java
@@ -98,11 +98,6 @@ public class HibernateSopDao extends HibernateSaveDao<Sop> implements HibernateP
   }
 
   @Override
-  public String propertyForId() {
-    return "sopId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStudyDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStudyDao.java
@@ -171,11 +171,6 @@ public class HibernateStudyDao implements StudyStore, HibernatePaginatedDataSour
   }
 
   @Override
-  public String propertyForId() {
-    return "studyId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     switch (original) {
     case "studyTypeId":

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTargetedSequencingDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTargetedSequencingDao.java
@@ -70,11 +70,6 @@ public class HibernateTargetedSequencingDao extends HibernateSaveDao<TargetedSeq
   }
 
   @Override
-  public String propertyForId() {
-    return "targetedSequencingId";
-  }
-
-  @Override
   public String propertyForSortColumn(String original) {
     return original;
   }


### PR DESCRIPTION
Apparently Hibernate always resolves "id" to the primary key, regardless of how it's defined on the entity model