### PR TITLE
GLT-3329: fixed bulk import error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Changes:
 
-
+  * Fixed error where importing into bulk tables would fail with no error message
 
 # 1.11.0
 

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -1709,33 +1709,19 @@ BulkUtils = (function($) {
                                 .concat(errorCols.map(function(errorCol) {
                                   return "* " + errorCol;
                                 })));
-                            return;
+                            return true;
                           }
                           if (maxRowLength > hot.countRows()) {
                             Utils.showOkDialog('Error', ['The spreadsheet contains ' + maxRowLength + ' rows, but the table only contains '
                                 + hot.countRows()]);
-                            return;
+                            return true;
                           }
-                          // validate read-only cells
-                          for (var colI = 0; colI < columnData.length; colI++) {
-                            var columnIndex = hotHeaders.indexOf(columnData[colI].heading);
-                            for (var rowIndex = 0; rowIndex < columnData[colI].data.length; rowIndex++) {
-                              var cellValue = hot.getDataAtCell(rowIndex, columnIndex);
-                              var importValue = columnData[colI].data[rowIndex];
-                              if (hot.getCellMeta(rowIndex, columnIndex).readOnly
-                                  && (!!importValue != !!cellValue || (!!importValue && !!cellValue && importValue != cellValue))) {
-                                Utils.showOkDialog('Error',
-                                    ['Values in read-only column \'' + columnData[colI].heading + '\' do not match']);
-                                return;
-                              }
-                            }
-                          }
+
                           // set values from spreadsheet
                           var changes = [];
                           columnData.forEach(function(column) {
                             var columnIndex = hotHeaders.indexOf(column.heading);
                             for (var rowIndex = 0; rowIndex < column.data.length; rowIndex++) {
-                              // hot.setDataAtCell(rowIndex, columnIndex, column.data[rowIndex], 'CopyPaste.paste');
                               changes.push([rowIndex, columnIndex, column.data[rowIndex]]);
                             }
                           });

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -559,8 +559,10 @@ var Utils = Utils
         });
         // dialog doesn't appear without this delay for some reason...
         setTimeout(function() {
-          workFunction();
-          dialog.dialog("close");
+          var dialogChanged = workFunction();
+          if (!dialogChanged) {
+            dialog.dialog("close");
+          }
         }, 100);
       },
 


### PR DESCRIPTION
Updating some fields may change whether others are read-only. Since all updates happen at once, we can't check whether they're read-only before making the change. It's also not worth trying to update in waves, as the onChange effects happen asynchronously. This means that it's now possible to break the table via bulk import - you can import an invalid value into a read-only field. You could fix it the same way though, or refresh the page and start over.