### PR TITLE
Long changelog messages

### DIFF
--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_array.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_array.sql
@@ -11,7 +11,7 @@ DROP TRIGGER IF EXISTS ArrayChange//
 CREATE TRIGGER ArrayChange BEFORE UPDATE ON Array
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN NEW.alias <> OLD.alias THEN CONCAT('alias: ', OLD.alias, ' → ', NEW.alias) END,
         CASE WHEN (NEW.serialNumber IS NULL) <> (OLD.serialNumber IS NULL) OR NEW.serialNumber <> OLD.serialNumber THEN CONCAT('serial number: ', COALESCE(OLD.serialNumber, 'n/a'), ' → ', COALESCE(NEW.serialNumber, 'n/a')) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_arrayrun.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_arrayrun.sql
@@ -11,7 +11,7 @@ DROP TRIGGER IF EXISTS ArrayRunChange//
 CREATE TRIGGER ArrayRunChange BEFORE UPDATE ON ArrayRun
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
     CASE WHEN NEW.alias <> OLD.alias THEN
       CONCAT('alias: ', OLD.alias, ' → ', NEW.alias)

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_box.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_box.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS BoxChange//
 CREATE TRIGGER BoxChange BEFORE UPDATE ON Box
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
     makeChangeMessage('alias', OLD.alias, NEW.alias),
     makeChangeMessage('barcode', OLD.identificationBarcode, NEW.identificationBarcode),

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_container.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_container.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS SequencerPartitionContainerChange//
 CREATE TRIGGER SequencerPartitionContainerChange BEFORE UPDATE ON SequencerPartitionContainer
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.identificationBarcode IS NULL) <> (OLD.identificationBarcode IS NULL) OR NEW.identificationBarcode <> OLD.identificationBarcode THEN CONCAT('identification barcode: ', COALESCE(OLD.identificationBarcode, 'n/a'), ' → ', COALESCE(NEW.identificationBarcode, 'n/a')) END,
         CASE WHEN NEW.sequencingContainerModelId <> OLD.sequencingContainerModelId THEN CONCAT('model: ', (SELECT alias FROM SequencingContainerModel WHERE sequencingContainerModelId = OLD.sequencingContainerModelId), ' → ', (SELECT alias FROM SequencingContainerModel WHERE sequencingContainerModelId = NEW.sequencingContainerModelId)) END);
@@ -36,7 +36,7 @@ DROP TRIGGER IF EXISTS PartitionChange//
 CREATE TRIGGER PartitionChange BEFORE UPDATE ON _Partition
 FOR EACH ROW
   BEGIN
-    DECLARE log_message varchar(500) CHARACTER SET utf8;
+    DECLARE log_message longtext CHARACTER SET utf8;
     DECLARE last_modifier bigint(20);
     DECLARE last_modified TIMESTAMP;
     DECLARE old_pool_name, new_pool_name, new_container_serial varchar(255) CHARACTER SET utf8;
@@ -95,7 +95,7 @@ DROP TRIGGER IF EXISTS OxfordNanoporeContainerChange//
 CREATE TRIGGER OxfordNanoporeContainerChange BEFORE UPDATE ON OxfordNanoporeContainer
 FOR EACH ROW
 BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.poreVersionId IS NULL) <> (OLD.poreVersionId IS NULL) OR NEW.poreVersionId <> OLD.poreVersionId THEN CONCAT('pore version: ', COALESCE((SELECT alias FROM PoreVersion WHERE poreVersionId = OLD.poreVersionId), 'n/a'), ' → ', COALESCE((SELECT alias FROM PoreVersion WHERE poreVersionId = NEW.poreVersionId), 'n/a')) END,
         CASE WHEN NEW.receivedDate <> OLD.receivedDate THEN CONCAT('received: ', OLD.receivedDate, ' → ', NEW.receivedDate) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_containerqc.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_containerqc.sql
@@ -18,7 +18,7 @@ DROP TRIGGER IF EXISTS ContainerQcUpdate//
 CREATE TRIGGER ContainerQcUpdate BEFORE UPDATE ON ContainerQC
 FOR EACH ROW
   BEGIN
-    DECLARE log_message varchar(500) CHARACTER SET utf8;
+    DECLARE log_message longtext CHARACTER SET utf8;
     SET log_message = CONCAT_WS(', ',
       CASE WHEN NEW.results <> OLD.results 
         THEN CONCAT('Updated ', (SELECT name FROM QCType WHERE qcTypeId = NEW.type), ' QC: ', OLD.results, ' → ', NEW.results, (SELECT units FROM QCType WHERE qcTypeId = NEW.type)) END);

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_experiment.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_experiment.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS ExperimentChange//
 CREATE TRIGGER ExperimentChange BEFORE UPDATE ON Experiment
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.accession IS NULL) <> (OLD.accession IS NULL) OR NEW.accession <> OLD.accession THEN CONCAT('accession: ', COALESCE(OLD.accession, 'n/a'), ' → ', COALESCE(NEW.accession, 'n/a')) END,
         CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_kit.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_kit.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS KitDescriptorChange//
 CREATE TRIGGER KitDescriptorChange BEFORE UPDATE ON KitDescriptor
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
     CASE WHEN NEW.name <> OLD.name THEN CONCAT('name: ', OLD.name, ' → ', NEW.name) END,
     CASE WHEN (NEW.version IS NULL) <> (OLD.version IS NULL) OR NEW.version <> OLD.version THEN CONCAT('version: ', COALESCE(OLD.version, 'n/a'), ' → ', COALESCE(NEW.version, 'n/a')) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_libraryqc.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_libraryqc.sql
@@ -18,7 +18,7 @@ DROP TRIGGER IF EXISTS LibraryQcUpdate//
 CREATE TRIGGER LibraryQcUpdate BEFORE UPDATE ON LibraryQC
 FOR EACH ROW
   BEGIN
-    DECLARE log_message varchar(500) CHARACTER SET utf8;
+    DECLARE log_message longtext CHARACTER SET utf8;
     SET log_message = CONCAT_WS(', ',
       CASE WHEN NEW.results <> OLD.results 
         THEN CONCAT('Updated ', (SELECT name FROM QCType WHERE qcTypeId = NEW.type), ' QC: ', OLD.results, ' → ', NEW.results, (SELECT units FROM QCType WHERE qcTypeId = NEW.type)) END);

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_pool.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_pool.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS PoolChange//
 CREATE TRIGGER PoolChange BEFORE UPDATE ON Pool
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,
         CASE WHEN (NEW.description IS NULL) <> (OLD.description IS NULL) OR NEW.description <> OLD.description THEN CONCAT('description: ', COALESCE(OLD.description, 'n/a'), ' → ', COALESCE(NEW.description, 'n/a')) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_poolorder.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_poolorder.sql
@@ -4,7 +4,7 @@ DROP TRIGGER IF EXISTS PoolOrderChange//
 CREATE TRIGGER PoolOrderChange BEFORE UPDATE ON PoolOrder
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
     makeChangeMessage('alias', OLD.alias, NEW.alias),
     makeChangeMessage('description', OLD.description, NEW.description),

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_poolqc.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_poolqc.sql
@@ -18,7 +18,7 @@ DROP TRIGGER IF EXISTS PoolQcUpdate//
 CREATE TRIGGER PoolQcUpdate BEFORE UPDATE ON PoolQC
 FOR EACH ROW
   BEGIN
-    DECLARE log_message varchar(500) CHARACTER SET utf8;
+    DECLARE log_message longtext CHARACTER SET utf8;
     SET log_message = CONCAT_WS(', ',
       CASE WHEN NEW.results <> OLD.results 
         THEN CONCAT('Updated ', (SELECT name FROM QCType WHERE qcTypeId = NEW.type), ' QC: ', OLD.results, ' → ', NEW.results, (SELECT units FROM QCType WHERE qcTypeId = NEW.type)) END);

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_project.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_project.sql
@@ -11,7 +11,7 @@ DROP TRIGGER IF EXISTS ProjectChange//
 CREATE TRIGGER ProjectChange BEFORE UPDATE ON Project
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,
         CASE WHEN (NEW.shortName IS NULL) <> (OLD.shortName IS NULL) OR NEW.shortName <> OLD.shortName THEN CONCAT('short name: ', COALESCE(OLD.shortName, 'n/a'), ' → ', COALESCE(NEW.shortName, 'n/a')) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_run.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_run.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS RunChange//
 CREATE TRIGGER RunChange BEFORE UPDATE ON Run
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
     makeChangeMessage('accession', OLD.accession, NEW.accession),
     makeChangeMessage('alias', OLD.alias, NEW.alias),
@@ -48,7 +48,7 @@ DROP TRIGGER IF EXISTS RunChangeLS454//
 CREATE TRIGGER RunChangeLS454 BEFORE UPDATE ON RunLS454
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN NEW.pairedEnd <> OLD.pairedEnd THEN CONCAT('ends: ', CASE WHEN OLD.pairedEnd THEN 'paired' ELSE 'single' END, ' → ', CASE WHEN NEW.pairedEnd THEN 'paired' ELSE 'single' END) END,
         CASE WHEN (NEW.cycles IS NULL) <> (OLD.cycles IS NULL) OR NEW.cycles <> OLD.cycles THEN CONCAT('cycles: ', COALESCE(OLD.cycles, 'n/a'), ' → ', COALESCE(NEW.cycles, 'n/a')) END);
@@ -70,7 +70,7 @@ DROP TRIGGER IF EXISTS RunChangeSolid//
 CREATE TRIGGER RunChangeSolid BEFORE UPDATE ON RunSolid
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN NEW.pairedEnd <> OLD.pairedEnd THEN CONCAT('ends: ', CASE WHEN OLD.pairedEnd THEN 'paired' ELSE 'single' END, ' → ', CASE WHEN NEW.pairedEnd THEN 'paired' ELSE 'single' END) END);
   IF log_message IS NOT NULL AND log_message <> '' THEN
@@ -90,7 +90,7 @@ DROP TRIGGER IF EXISTS RunChangeIllumina//
 CREATE TRIGGER RunChangeIllumina BEFORE UPDATE ON RunIllumina
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   -- Note: cycles are not change logged as they are expected to change a lot via Run Scanner during a run 
   SET log_message = CONCAT_WS(', ',
         CASE WHEN NEW.pairedEnd <> OLD.pairedEnd THEN CONCAT('ends: ', CASE WHEN OLD.pairedEnd THEN 'paired' ELSE 'single' END, ' → ', CASE WHEN NEW.pairedEnd THEN 'paired' ELSE 'single' END) END,
@@ -115,7 +115,7 @@ DROP TRIGGER IF EXISTS RunChangeOxfordNanopore//
 CREATE TRIGGER RunChangeOxfordNanopore BEFORE UPDATE ON RunOxfordNanopore
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.minKnowVersion IS NULL) <> (OLD.minKnowVersion IS NULL) OR NEW.minKnowVersion <> OLD.minKnowVersion THEN CONCAT('MinKNOW version: ', COALESCE(OLD.minKnowVersion, 'n/a'), ' → ', COALESCE(NEW.minKnowVersion, 'n/a')) END,
         CASE WHEN (NEW.protocolVersion IS NULL) <> (OLD.protocolVersion IS NULL) OR NEW.protocolVersion <> OLD.protocolVersion THEN CONCAT('Protocol version: ', COALESCE(OLD.protocolVersion, 'n/a'), ' → ', COALESCE(NEW.protocolVersion, 'n/a')) END);

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_runpartition.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_runpartition.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS RunPartitionUpdate//
 CREATE TRIGGER RunPartitionUpdate BEFORE UPDATE ON Run_Partition
 FOR EACH ROW
   BEGIN
-	DECLARE log_message varchar(500) CHARACTER SET utf8;
+	DECLARE log_message longtext CHARACTER SET utf8;
 	DECLARE log_columns varchar(500) CHARACTER SET utf8;
     SELECT
       spc.identificationBarcode,
@@ -51,7 +51,7 @@ DROP TRIGGER IF EXISTS RunPartitionLibraryAliquotUpdate//
 CREATE TRIGGER RunPartitionLibraryAliquotUpdate BEFORE UPDATE ON Run_Partition_LibraryAliquot
 FOR EACH ROW
   BEGIN
-	DECLARE log_message varchar(500) CHARACTER SET utf8;
+	DECLARE log_message longtext CHARACTER SET utf8;
 	DECLARE log_columns varchar(500) CHARACTER SET utf8;
     SELECT
       spc.identificationBarcode,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_sampleqc.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_sampleqc.sql
@@ -18,7 +18,7 @@ DROP TRIGGER IF EXISTS SampleQcUpdate//
 CREATE TRIGGER SampleQcUpdate BEFORE UPDATE ON SampleQC
 FOR EACH ROW
   BEGIN
-    DECLARE log_message varchar(500) CHARACTER SET utf8;
+    DECLARE log_message longtext CHARACTER SET utf8;
     SET log_message = CONCAT_WS(', ',
       CASE WHEN NEW.results <> OLD.results 
         THEN CONCAT('Updated ', (SELECT name FROM QCType WHERE qcTypeId = NEW.type), ' QC: ', OLD.results, ' → ', NEW.results, (SELECT units FROM QCType WHERE qcTypeId = NEW.type)) END);

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_storage.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_storage.sql
@@ -13,7 +13,7 @@ DROP TRIGGER IF EXISTS StorageLocationChange//
 CREATE TRIGGER StorageLocationChange BEFORE UPDATE ON StorageLocation
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   IF NEW.locationUnit = 'FREEZER' THEN
     SET log_message = CONCAT_WS(', ',
           CASE WHEN NEW.alias <> OLD.alias THEN CONCAT('alias: ', OLD.alias, ' → ', NEW.alias) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_study.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_study.sql
@@ -5,7 +5,7 @@ DROP TRIGGER IF EXISTS StudyChange//
 CREATE TRIGGER StudyChange BEFORE UPDATE ON Study
 FOR EACH ROW
   BEGIN
-  DECLARE log_message varchar(500) CHARACTER SET utf8;
+  DECLARE log_message longtext CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
         CASE WHEN (NEW.accession IS NULL) <> (OLD.accession IS NULL) OR NEW.accession <> OLD.accession THEN CONCAT('accession: ', COALESCE(OLD.accession, 'n/a'), ' → ', COALESCE(NEW.accession, 'n/a')) END,
         CASE WHEN (NEW.alias IS NULL) <> (OLD.alias IS NULL) OR NEW.alias <> OLD.alias THEN CONCAT('alias: ', COALESCE(OLD.alias, 'n/a'), ' → ', COALESCE(NEW.alias, 'n/a')) END,

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_transfer.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_transfer.sql
@@ -4,7 +4,7 @@ DROP TRIGGER IF EXISTS TransferChange//
 CREATE TRIGGER TransferChange BEFORE UPDATE ON Transfer
 FOR EACH ROW
   BEGIN
-    DECLARE log_message varchar(500) CHARACTER SET utf8;
+    DECLARE log_message longtext CHARACTER SET utf8;
     SET log_message = CONCAT_WS(', ',
       makeChangeMessage('transfer request name', OLD.transferRequestName, NEW.transferRequestName),
       makeChangeMessage('transfer time', OLD.transferTime, NEW.transferTime),

--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_workset.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_workset.sql
@@ -4,7 +4,7 @@ DROP TRIGGER IF EXISTS WorksetChange//
 CREATE TRIGGER WorksetChange BEFORE UPDATE ON Workset
 FOR EACH ROW
   BEGIN
-    DECLARE log_message varchar(500) CHARACTER SET utf8;
+    DECLARE log_message longtext CHARACTER SET utf8;
     SET log_message = CONCAT_WS(', ',
       makeChangeMessage('alias', OLD.alias, NEW.alias),
       makeChangeMessage('description', OLD.description, NEW.description)

--- a/sqlstore/src/main/resources/db/migration_beforeMigrate/00_functions.sql
+++ b/sqlstore/src/main/resources/db/migration_beforeMigrate/00_functions.sql
@@ -45,7 +45,7 @@ BEGIN
 END//
 
 DROP FUNCTION IF EXISTS makeChangeMessage//
-CREATE FUNCTION makeChangeMessage(fieldName varchar(255), beforeVal varchar(255), afterVal varchar(255)) RETURNS varchar(255)
+CREATE FUNCTION makeChangeMessage(fieldName varchar(255), beforeVal varchar(255), afterVal varchar(255)) RETURNS longtext
 BEGIN
   IF isChanged(beforeVal, afterVal) THEN
     RETURN CONCAT(fieldName, ': ', COALESCE(beforeVal, 'n/a'), ' → ', COALESCE(afterVal, 'n/a'));


### PR DESCRIPTION
Applying these migrations and setting runpath or description on a run from a 255-char string to a different 255-char string still causes `Caused by: com.mysql.jdbc.MysqlDataTruncation: Data truncation: Data too long for column 'makeChangeMessage('description', OLD.description, NEW.description)' at row 1` or similar