### PR TITLE
GLT-3408: fixed failed QCs showing as checkmark

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Changes:
 
-
+  * Fixed failed QCs showing as checkmark on QCs lists
 
 # 1.19.1
 

--- a/miso-web/src/main/webapp/scripts/list_qc.js
+++ b/miso-web/src/main/webapp/scripts/list_qc.js
@@ -105,7 +105,7 @@ ListTarget.qc = function(qcTarget) {
           if (type === 'display') {
             var qcType = Utils.array.findUniqueOrThrow(Utils.array.idPredicate(full.qcTypeId), Constants.qcTypes);
             if (qcType.precisionAfterDecimal < 0) {
-              return ListUtils.render.booleanChecks(!!data, type, full);
+              return ListUtils.render.booleanChecks(data > 0, type, full);
             } else {
               return data + " " + qcType.units;
             }


### PR DESCRIPTION
`precisionAfterDecimal < 0` means it's a boolean (pass/fail) QC. `results` (`data` in the render function) is a decimal string though, so it will be either "0" or "1"