### PR TITLE
Add 2 new IlluminaExperiment types for Illumina sample sheet CSV creation

### DIFF
--- a/changes/add_2532_illumina_experiment_types.md
+++ b/changes/add_2532_illumina_experiment_types.md
@@ -1,0 +1,1 @@
+2 new IlluminaExperiment types for Application "FASTQ Only" for Assays "Nextera XT" and "TruSeq Nano DNA" for Illumina sample sheet CSV creation.

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/IlluminaExperiment.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/IlluminaExperiment.java
@@ -64,6 +64,29 @@ public enum IlluminaExperiment {
       settings.put("AdapterRead2", "AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT");
 
     }
+  },
+  FASTQ_ONLY_NEXTERA_XT("FASTQ Only (Nextera XT)") {
+
+    @Override
+    protected void applyAttribute(Map<String, String> header, Map<String, String> settings) {
+      header.put("Workflow", "GenerateFASTQ");
+      header.put("Application", "FASTQ Only");
+      header.put("Assay", "Nextera XT");
+      settings.put("ReverseComplement", "0");
+      settings.put("Adapter", "CTGTCTCTTATACACATCT");
+    }
+  },
+  FASTQ_ONLY_TRUSEQ_NANO_DNA("FASTQ Only (TruSeq Nano DNA)") {
+
+    @Override
+    protected void applyAttribute(Map<String, String> header, Map<String, String> settings) {
+      header.put("Workflow", "GenerateFASTQ");
+      header.put("Application", "FASTQ Only");
+      header.put("Assay", "TruSeq Nano DNA");
+      settings.put("ReverseComplement", "0");
+      settings.put("Adapter", "AGATCGGAAGAGCACACGTCTGAACTCCAGTCA");
+      settings.put("AdapterRead2", "AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT");
+    }
   };
   private static final DateTimeFormatter MDY = DateTimeFormatter.ofPattern("M/d/yyyy");
 


### PR DESCRIPTION
This PR addresses #2532 adding 2 new IlluminaExperiment types for Application "FASTQ Only" for Assays "Nextera XT" and "TruSeq Nano DNA" for Illumina sample sheet CSV creation.