### PR TITLE
[GLT-3600] fix Run Scanner updating runs without changes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,7 +32,7 @@ Starting with version 1.29.0, the format of this file is based on
 
 ### Changed
 
-* * When receiving samples, an existing ghost tissue must now match the
+* When receiving samples, an existing ghost tissue must now match the
   timepoint in addition to tissue origin, tissue type, times received, tube
   number, and passage in order for the new sample to be parented to it
 

--- a/changes/fix_runscanner_kit_type.md
+++ b/changes/fix_runscanner_kit_type.md
@@ -1,0 +1,2 @@
+It was possible for runs from Run Scanner to be assigned kits of the wrong
+kit type as the sequencing kit

--- a/changes/fix_runscanner_updates.md
+++ b/changes/fix_runscanner_updates.md
@@ -1,0 +1,2 @@
+Runs and containers from Run Scanner were being updated even when they were
+not changed

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/KitDescriptorService.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/KitDescriptorService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 import uk.ac.bbsrc.tgac.miso.core.data.type.KitType;
+import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.util.PaginatedDataSource;
 
 public interface KitDescriptorService extends DeleterService<KitDescriptor>, ListService<KitDescriptor>, PaginatedDataSource<KitDescriptor>,
@@ -14,7 +15,7 @@ public interface KitDescriptorService extends DeleterService<KitDescriptor>, Lis
 
   public KitDescriptor getByName(String name) throws IOException;
 
-  public KitDescriptor getByPartNumber(String partNumber) throws IOException;
+  public KitDescriptor getByPartNumber(String partNumber, KitType kitType, PlatformType platformType) throws IOException;
 
   public List<KitDescriptor> search(KitType type, String search) throws IOException;
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultKitDescriptorService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultKitDescriptorService.java
@@ -20,6 +20,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryAliquot;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.TargetedSequencing;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 import uk.ac.bbsrc.tgac.miso.core.data.type.KitType;
+import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.security.AuthorizationManager;
 import uk.ac.bbsrc.tgac.miso.core.service.KitDescriptorService;
 import uk.ac.bbsrc.tgac.miso.core.service.TargetedSequencingService;
@@ -151,8 +152,8 @@ public class DefaultKitDescriptorService implements KitDescriptorService {
   }
 
   @Override
-  public KitDescriptor getByPartNumber(String partNumber) throws IOException {
-    return kitStore.getKitDescriptorByPartNumber(partNumber);
+  public KitDescriptor getByPartNumber(String partNumber, KitType kitType, PlatformType platformType) throws IOException {
+    return kitStore.getKitDescriptorByPartNumber(partNumber, kitType, platformType);
   }
 
   @Override

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultRunService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultRunService.java
@@ -670,9 +670,6 @@ public class DefaultRunService implements RunService, PaginatedDataSource<Run> {
       create(target);
     } else if (isMutated) {
       update(target);
-    } else {
-      Run original = get(target.getId());
-      validateChanges(original, target);
     }
     return isNew;
   }

--- a/sqlstore/src/it/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDaoIT.java
+++ b/sqlstore/src/it/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDaoIT.java
@@ -125,13 +125,15 @@ public class HibernateKitDaoIT extends AbstractDAOTest {
 
   @Test
   public void testGetKitDescriptorByPartNumber() throws IOException {
-    KitDescriptor kitDescriptor = dao.getKitDescriptorByPartNumber("k002");
+    KitDescriptor kitDescriptor = dao.getKitDescriptorByPartNumber("k002", KitType.LIBRARY,
+        PlatformType.ILLUMINA);
     assertThat(kitDescriptor.getName(), is("Test Kit 2"));
   }
 
   @Test
   public void testGetKitDescriptorByPartNumberNotFound() throws IOException {
-    KitDescriptor kitDescriptor = dao.getKitDescriptorByPartNumber("doesnotexist");
+    KitDescriptor kitDescriptor = dao.getKitDescriptorByPartNumber("doesnotexist", KitType.LIBRARY,
+        PlatformType.ILLUMINA);
     assertNull(kitDescriptor);
   }
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/KitStore.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/KitStore.java
@@ -31,6 +31,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryAliquot;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.TargetedSequencing;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 import uk.ac.bbsrc.tgac.miso.core.data.type.KitType;
+import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.util.PaginatedDataSource;
 
 /**
@@ -47,7 +48,7 @@ public interface KitStore extends Store<Kit>, PaginatedDataSource<KitDescriptor>
 
   public KitDescriptor getKitDescriptorByName(String name) throws IOException;
 
-  public KitDescriptor getKitDescriptorByPartNumber(String partNumber) throws IOException;
+  public KitDescriptor getKitDescriptorByPartNumber(String partNumber, KitType kitType, PlatformType platformType) throws IOException;
 
   public List<KitDescriptor> listAllKitDescriptors() throws IOException;
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDao.java
@@ -47,6 +47,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SequencerPartitionContainerImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.TargetedSequencing;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 import uk.ac.bbsrc.tgac.miso.core.data.type.KitType;
+import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.QcType;
 import uk.ac.bbsrc.tgac.miso.core.util.DateType;
 import uk.ac.bbsrc.tgac.miso.persistence.KitStore;
@@ -115,12 +116,12 @@ public class HibernateKitDao implements KitStore, HibernatePaginatedDataSource<K
   }
 
   @Override
-  public KitDescriptor getKitDescriptorByPartNumber(String partNumber) throws IOException {
-    Criteria criteria = currentSession().createCriteria(KitDescriptor.class);
-    criteria.add(Restrictions.eq("partNumber", partNumber));
-    @SuppressWarnings("unchecked")
-    List<KitDescriptor> kitDescriptors = criteria.list();
-    return kitDescriptors.size() == 0 ? null : kitDescriptors.get(0);
+  public KitDescriptor getKitDescriptorByPartNumber(String partNumber, KitType kitType, PlatformType platformType) throws IOException {
+    return (KitDescriptor) currentSession().createCriteria(KitDescriptor.class)
+        .add(Restrictions.eq("partNumber", partNumber))
+        .add(Restrictions.eq("kitType", kitType))
+        .add(Restrictions.eq("platformType", platformType))
+        .uniqueResult();
   }
 
   @Override

--- a/sqlstore/src/main/resources/db/migration/V8501__mark_run_failed_dates.sql
+++ b/sqlstore/src/main/resources/db/migration/V8501__mark_run_failed_dates.sql
@@ -1,0 +1,5 @@
+UPDATE Run SET
+  completionDate = startDate,
+  lastModifier = (SELECT userId FROM User WHERE loginName = 'admin'),
+  lastModified = NOW()
+WHERE health = 'Failed' AND completionDate IS NULL;


### PR DESCRIPTION
Putting Run Scanner runs through the standard validation revealed a few minor data issues. All should be resolved automatically with this release. Notably:

* Runs that are marked failed, but have no completion date will have their completion date set to match the start date (via Flyway migration)
* There are some ONT kits that are duplicated to be used as both library and sequencing kits. In some cases, the library kits were wrongly assigned as sequencing kits. These will be corrected automatically the next time MISO receives the affected runs from Run Scanner