### PR TITLE
[#2621] fix DB migration for MariaDB 10.2.41

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V0320__auto_main.sql
+++ b/sqlstore/src/main/resources/db/migration/V0320__auto_main.sql
@@ -64,9 +64,12 @@ UPDATE QCType SET precisionAfterDecimal = 2 WHERE precisionAfterDecimal = 0;
 
 -- printer_rename
 
--- StartNoTest
-UPDATE Printer SET backend = 'BRADY_FTP', configuration = JSON_OBJECT('host', JSON_EXTRACT(CAST(configuration AS JSON), '$.host'), 'pin', JSON_EXTRACT(CAST(configuration AS JSON), '$.password'))  WHERE backend = 'FTP';
--- EndNoTest
+UPDATE Printer SET
+  backend = 'BRADY_FTP',
+  configuration = JSON_OBJECT('host', JSON_EXTRACT(configuration, '$.host'),
+  'pin', JSON_EXTRACT(configuration, '$.password'))
+WHERE backend = 'FTP';
+
 UPDATE Printer SET driver = 'BRADY_BPT_635_488' WHERE backend = 'BRADY_M80';
 UPDATE Printer SET driver = 'BRADY_THT_181_492_3' WHERE backend = 'BRADY_STANDARD';
 

--- a/sqlstore/src/main/resources/db/migration/beforeValidate.sql
+++ b/sqlstore/src/main/resources/db/migration/beforeValidate.sql
@@ -23,6 +23,8 @@ BEGIN
     UPDATE flyway_schema_history SET checksum = 1248674807 WHERE version = '1060';
     UPDATE flyway_schema_history SET checksum = 1770487871 WHERE version = '1100';
     UPDATE flyway_schema_history SET checksum = 876069334 WHERE version = '1200';
+    -- V1210 was altered for compatibility with mariadb 10.2.41
+    UPDATE flyway_schema_history SET checksum = 677713310 WHERE version = '0320';
   END IF;
 END//
 


### PR DESCRIPTION
MariaDB doesn't have a JSON datatype, but `JSON_EXTRACT` works on strings in MySQL too, so the `CAST` is not necessary