### PR TITLE
[#2626] align log4j and slf4j versions

### DIFF
--- a/changes/fix_slf4j_version.md
+++ b/changes/fix_slf4j_version.md
@@ -1,0 +1,1 @@
+An issue that caused Pinery-MISO to fail and return 500 status in some cases

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2017. Earlham Institute, Norwich, UK, and
-  ~ the Ontario Institute for Cancer Research, Ontario, Canada. 
-  ~ MISO project contacts: Robert Davey @ EI (formerly TGAC), 
-  ~ Morgan Taschuk @ OICR 
-  ~
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses />.
-  ~
-  ~ **********************************************************************
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -133,7 +108,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/integration-tools/pom.xml
+++ b/integration-tools/pom.xml
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2017. Earlham Institute, Norwich, UK, and
-  ~ the Ontario Institute for Cancer Research, Ontario, Canada. 
-  ~ MISO project contacts: Robert Davey @ EI (formerly TGAC), 
-  ~ Morgan Taschuk @ OICR 
-  ~
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses />.
-  ~
-  ~ **********************************************************************
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -69,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/miso-service/pom.xml
+++ b/miso-service/pom.xml
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2017. Earlham Institute, Norwich, UK, and
-  ~ the Ontario Institute for Cancer Research, Ontario, Canada. 
-  ~ MISO project contacts: Robert Davey @ EI (formerly TGAC), 
-  ~ Morgan Taschuk @ OICR 
-  ~
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses />.
-  ~
-  ~ **********************************************************************
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -57,7 +32,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2017. Earlham Institute, Norwich, UK, and
-  ~ the Ontario Institute for Cancer Research, Ontario, Canada. 
-  ~ MISO project contacts: Robert Davey @ EI (formerly TGAC), 
-  ~ Morgan Taschuk @ OICR 
-  ~
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses />.
-  ~
-  ~ **********************************************************************
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -152,7 +127,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>

--- a/pinery-miso/pom.xml
+++ b/pinery-miso/pom.xml
@@ -15,7 +15,7 @@
     <mysql.db>lims</mysql.db>
     <mysql.user>tgaclims</mysql.user>
     <mysql.pw>tgaclims</mysql.pw>
-    <pinery.version>2.21.1-SNAPSHOT</pinery.version>
+    <pinery.version>2.21.1</pinery.version>
     <spring-version>5.3.14</spring-version><!-- must match version used by Pinery -->
     <jackson.version>2.10.0</jackson.version>
   </properties>

--- a/pinery-miso/pom.xml
+++ b/pinery-miso/pom.xml
@@ -16,7 +16,7 @@
     <mysql.user>tgaclims</mysql.user>
     <mysql.pw>tgaclims</mysql.pw>
     <pinery.version>2.21.1-SNAPSHOT</pinery.version>
-    <spring-version>5.2.18.RELEASE</spring-version><!-- must match version used by Pinery -->
+    <spring-version>5.3.14</spring-version><!-- must match version used by Pinery -->
     <jackson.version>2.10.0</jackson.version>
   </properties>
 

--- a/pinery-miso/pom.xml
+++ b/pinery-miso/pom.xml
@@ -15,7 +15,7 @@
     <mysql.db>lims</mysql.db>
     <mysql.user>tgaclims</mysql.user>
     <mysql.pw>tgaclims</mysql.pw>
-    <pinery.version>2.21.0</pinery.version>
+    <pinery.version>2.21.1-SNAPSHOT</pinery.version>
     <spring-version>5.2.18.RELEASE</spring-version><!-- must match version used by Pinery -->
     <jackson.version>2.10.0</jackson.version>
   </properties>
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j18-impl</artifactId>
+        <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j.version}</version>
       </dependency>
       <dependency>

--- a/sqlstore/pom.xml
+++ b/sqlstore/pom.xml
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2017. Earlham Institute, Norwich, UK, and
-  ~ the Ontario Institute for Cancer Research, Ontario, Canada. 
-  ~ MISO project contacts: Robert Davey @ EI (formerly TGAC), 
-  ~ Morgan Taschuk @ OICR 
-  ~
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses />.
-  ~
-  ~ **********************************************************************
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -95,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
`log4j-slf4j18-impl` uses a beta version of slf4j, so we'll stick with `log4j-slf4j-impl` for now instead

Requires a Pinery release and updating the Pinery version in `pinery-miso/pom.xml` before merging