### PR TITLE
update to Jackson 2.13.2 via BOM, and Pinery's Spring version

### DIFF
--- a/changes/fix_dependencies.md
+++ b/changes/fix_dependencies.md
@@ -1,0 +1,1 @@
+updated Spring and Jackson dependencies with known vulnerabilities

--- a/changes/note_pinery.md
+++ b/changes/note_pinery.md
@@ -1,0 +1,1 @@
+Updated to Pinery 2.22.1

--- a/changes/note_runscanner.md
+++ b/changes/note_runscanner.md
@@ -1,0 +1,1 @@
+Updated to Run Scanner 1.13.2

--- a/pinery-miso/pom.xml
+++ b/pinery-miso/pom.xml
@@ -16,7 +16,7 @@
     <mysql.user>tgaclims</mysql.user>
     <mysql.pw>tgaclims</mysql.pw>
     <pinery.version>2.22.1</pinery.version>
-    <spring-version>5.3.14</spring-version><!-- must match version used by Pinery -->
+    <spring-version>5.3.18</spring-version><!-- must match version used by Pinery -->
   </properties>
 
   <dependencies>

--- a/pinery-miso/pom.xml
+++ b/pinery-miso/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>pinery-miso</artifactId>
   <name>pinery-miso</name>
   <packaging>war</packaging>
-  
+
   <properties>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <skipITs>true</skipITs>
@@ -17,7 +17,6 @@
     <mysql.pw>tgaclims</mysql.pw>
     <pinery.version>2.22.1</pinery.version>
     <spring-version>5.3.14</spring-version><!-- must match version used by Pinery -->
-    <jackson.version>2.10.0</jackson.version>
   </properties>
 
   <dependencies>
@@ -79,7 +78,7 @@
       <artifactId>sqlstore</artifactId>
     </dependency>
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>integration-test-setup</id>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
     <poi.version>3.17</poi.version>
     <prometheus.version>0.0.21</prometheus.version>
     <prometheus.jmx.version>0.9</prometheus.jmx.version>
-    <jackson.version>2.8.6</jackson.version>
     <flyway.version>5.2.4</flyway.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -170,7 +169,7 @@
         <groupId>com.j2html</groupId>
         <artifactId>j2html</artifactId>
         <version>1.4.0</version>
-      </dependency>    
+      </dependency>
       <dependency>
         <groupId>com.opencsv</groupId>
         <artifactId>opencsv</artifactId>
@@ -409,24 +408,12 @@
         <version>1.6.12</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${jackson.version}</version>
+        <!-- keeps Jackson dependencies in sync -->
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.13.2.20220328</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.github.bonigarcia</groupId>


### PR DESCRIPTION
Jira ticket or GitHub issue: 

- [x] Includes a change file

Requires Pinery release and updated Pinery version in this PR before merging