### PR TITLE
[GLT-3675] sample download sheet updates

### DIFF
--- a/changes/change_download_columns.md
+++ b/changes/change_download_columns.md
@@ -1,0 +1,2 @@
+Tracking List and Transfer List V2 sample download sheets now include Box and
+Position columns

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/spreadsheet/SampleSpreadSheets.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/spreadsheet/SampleSpreadSheets.java
@@ -31,6 +31,8 @@ public enum SampleSpreadSheets implements Spreadsheet<Sample> {
       Column.forString("Tissue Origin", true, detailedSample(SampleTissue.class, st -> st.getTissueOrigin().getAlias(), "")), //
       Column.forString("Type", true, dnaOrRna()), //
       Column.forString("Barcode", Sample::getIdentificationBarcode), //
+      Column.forString("Box", sam -> sam.getBox() == null ? null : sam.getBox().getAlias()), //
+      Column.forString("Position", sam -> sam.getBoxPosition()), //
       Column.forString("Class", true, sam -> LimsUtils.isDetailedSample(sam) ? ((DetailedSample) sam).getSampleClass().getAlias() : null), //
       Column.forString("External Identifier", true, detailedSample(SampleIdentity.class, SampleIdentity::getExternalName, "")), //
       Column.forString("Group ID", true, sam -> LimsUtils.isDetailedSample(sam) ? ((DetailedSample) sam).getGroupId() : null), //
@@ -67,6 +69,8 @@ public enum SampleSpreadSheets implements Spreadsheet<Sample> {
       Column.forString("Origin", detailedSample(SampleTissue.class, st -> st.getTissueOrigin().getAlias(), "")), //
       Column.forString("Type", detailedSample(SampleTissue.class, st -> st.getTissueType().getAlias(), "")), //
       Column.forString("Barcode", Sample::getIdentificationBarcode), //
+      Column.forString("Box", sam -> sam.getBox() == null ? null : sam.getBox().getAlias()), //
+      Column.forString("Position", sam -> sam.getBoxPosition()), //
       Column.forString("Class", true, sam -> LimsUtils.isDetailedSample(sam) ? ((DetailedSample) sam).getSampleClass().getAlias() : null), //
       Column.forString("External Identifier", detailedSample(SampleIdentity.class, SampleIdentity::getExternalName, "")), //
       Column.forString("Group ID", effectiveGroupIdProperty(GroupIdentifiable::getGroupId)), //

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/context/WebConfig.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/context/WebConfig.java
@@ -1,16 +1,17 @@
 package uk.ac.bbsrc.tgac.miso.webapp.context;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.web.bind.support.SessionAttributeStore;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 
@@ -71,10 +72,10 @@ public class WebConfig extends WebMvcConfigurationSupport {
 
   @Bean(name = "objectMapper")
   public ObjectMapper objectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new JsonStringValidator());
+    ObjectMapper mapper = Jackson2ObjectMapperBuilder.json()
+        .modulesToInstall(new JsonStringValidator())
+        .build();
     mapper.getFactory().setCharacterEscapes(new JsonCharacterEscapes());
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return mapper;
   }
 }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/BoxRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/BoxRestController.java
@@ -204,7 +204,7 @@ public class BoxRestController extends RestController {
    * @param boxId ID of the Box
    * @return JSON object with "hashCode" field representing the hash code of the spreadsheet filename
    */
-  @GetMapping(value = "/{boxId}/spreadsheet")
+  @GetMapping(value = "/{boxId}/spreadsheet", produces = "application/octet-stream")
   public @ResponseBody JSONObject createSpreadsheet(@PathVariable("boxId") Long boxId) {
     try {
       return exportBoxContentsForm(boxId);

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/ContainerRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/ContainerRestController.java
@@ -150,7 +150,7 @@ public class ContainerRestController extends RestController {
     containerService.bulkDelete(containers);
   }
 
-  @PostMapping(value = "/spreadsheet")
+  @PostMapping(value = "/spreadsheet", produces = "application/octet-stream")
   @ResponseBody
   public HttpEntity<byte[]> getSpreadsheet(@RequestBody SpreadsheetRequest request, HttpServletResponse response,
       UriComponentsBuilder uriBuilder) {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/HotRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/HotRestController.java
@@ -54,7 +54,7 @@ public class HotRestController extends RestController {
   @Value("${miso.detailed.sample.enabled}")
   private Boolean detailedSample;
 
-  @PostMapping("/spreadsheet")
+  @PostMapping(value = "/spreadsheet", produces = "application/octet-stream")
   public HttpEntity<byte[]> downloadSpreadsheet(@RequestParam(name = "format", required = true) String format,
       @RequestBody SpreadsheetDataDto dto, HttpServletResponse response) {
     return MisoWebUtils.generateSpreadsheet(dto.getHeaders(), dto.getRows(), detailedSample, SpreadSheetFormat.valueOf(format), response);

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryAliquotRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryAliquotRestController.java
@@ -172,7 +172,7 @@ public class LibraryAliquotRestController extends RestController {
         .collect(Collectors.toList());
   }
 
-  @PostMapping(value = "/spreadsheet")
+  @PostMapping(value = "/spreadsheet", produces = "application/octet-stream")
   @ResponseBody
   public HttpEntity<byte[]> getSpreadsheet(@RequestBody SpreadsheetRequest request, HttpServletResponse response,
       UriComponentsBuilder uriBuilder) throws IOException {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryRestController.java
@@ -215,7 +215,7 @@ public class LibraryRestController extends RestController {
         .collect(Collectors.toList());
   }
 
-  @PostMapping(value = "/spreadsheet")
+  @PostMapping(value = "/spreadsheet", produces = "application/octet-stream")
   @ResponseBody
   public HttpEntity<byte[]> getSpreadsheet(@RequestBody SpreadsheetRequest request, HttpServletResponse response) throws IOException {
     return MisoWebUtils.generateSpreadsheet(request, libraryService::listByIdList, detailedSample, LibrarySpreadSheets::valueOf, response);

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/PoolRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/PoolRestController.java
@@ -491,14 +491,14 @@ public class PoolRestController extends RestController {
         .collect(Collectors.toList());
   }
 
-  @PostMapping(value = "/spreadsheet")
+  @PostMapping(value = "/spreadsheet", produces = "application/octet-stream")
   @ResponseBody
   public HttpEntity<byte[]> getSpreadsheet(@RequestBody SpreadsheetRequest request, HttpServletResponse response,
       UriComponentsBuilder uriBuilder) throws IOException {
     return MisoWebUtils.generateSpreadsheet(request, poolService::listByIdList, detailedSample, PoolSpreadSheets::valueOf, response);
   }
 
-  @PostMapping(value = "/contents/spreadsheet")
+  @PostMapping(value = "/contents/spreadsheet", produces = "application/octet-stream")
   @ResponseBody
   public HttpEntity<byte[]> getContentsSpreadsheet(@RequestBody SpreadsheetRequest request, HttpServletResponse response,
       UriComponentsBuilder uriBuilder) throws IOException {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/RunRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/RunRestController.java
@@ -674,7 +674,7 @@ public class RunRestController extends RestController {
     RestUtils.bulkDelete("Run", ids, runService);
   }
 
-  @PostMapping(value = "/spreadsheet")
+  @PostMapping(value = "/spreadsheet", produces = "application/octet-stream")
   @ResponseBody
   public HttpEntity<byte[]> getSpreadsheet(@RequestBody SpreadsheetRequest request, HttpServletResponse response,
       UriComponentsBuilder uriBuilder) throws IOException {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleRestController.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -347,7 +348,7 @@ public class SampleRestController extends RestController {
         .collect(Collectors.toList());
   }
 
-  @PostMapping(value = "/spreadsheet")
+  @PostMapping(value = "/spreadsheet", produces = "application/octet-stream")
   @ResponseBody
   public HttpEntity<byte[]> getSpreadsheet(@RequestBody SpreadsheetRequest request, HttpServletResponse response) throws IOException {
     return MisoWebUtils.generateSpreadsheet(request, sampleService::listByIdList, detailedSample, SampleSpreadSheets::valueOf, response);

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -645,6 +645,7 @@ var Utils = Utils
         request.open(data ? 'POST' : 'GET', url);
         request.responseType = 'blob';
         request.setRequestHeader('Content-Type', 'application/json; charset=utf8');
+        request.setRequestHeader('Accept', 'application/octet-stream');
         request.onreadystatechange = function() {
           if (request.readyState === 4) {
             dialog.dialog("close");


### PR DESCRIPTION
Includes fix for bug that was caused recent change to default ObjectMapper used in MessageConverter

* Changed `ObjectMapper` creation to use `Jackson2ObjectMapperBuilder` so it would include some default settings set by Spring
* Changed spreadsheet requests to set `Accept` header, which tells Spring which `MessageConverter` to use. I'm really not sure how it was choosing the correct one before, or how defining a `MessageConverter` for JSON affected that since the default converters are still there
* Added `produces` parameter to mapping annotation for downloads, which also determines the MessageConverter to use. Only this *or* the accept header (above) is needed, but setting both to be safe
* Not including a change file for the fix since the bug was not in a release

Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-3675

- [x] Includes a change file
