### PR TITLE
[GLT-3694] fixed bulk actions missing on Edit Transfer page

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,10 @@ Starting with version 1.29.0, the format of this file is based on
 * Error when attempting to move transfer items to a different box
 * Security improvements
 
+### Known Issues
+
+* Some bulk actions are missing from the Items list on the Edit Transfer page
+
 
 ## [1.44.0] - 2022-05-19
 

--- a/changes/fix_transferItemActions.md
+++ b/changes/fix_transferItemActions.md
@@ -1,0 +1,1 @@
+Bulk actions missing from the Items list on the Edit Transfer page

--- a/miso-web/src/main/webapp/scripts/transfer_ajax.js
+++ b/miso-web/src/main/webapp/scripts/transfer_ajax.js
@@ -122,7 +122,7 @@ var Transfer = (function($) {
     $('#type-toolbar').remove();
     var toolbar = $('<div>').prop('id', 'type-toolbar');
     toolbar.append(items);
-    $('#listItems > .fg-toolbar').append(toolbar);
+    $('#listItems > .ui-toolbar').append(toolbar);
   }
 
 })(jQuery);


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-3694

- [x] Includes a change file

Since it's just a small JS change, I will hotfix stage and prod after approved