### PR TITLE
[#2684] updated to latest Spring and Hibernate versions

### DIFF
--- a/changes/fix_dependencies.md
+++ b/changes/fix_dependencies.md
@@ -1,0 +1,1 @@
+Updated Spring and Hibernate libraries (security patches)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -119,10 +119,6 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/core/src/main/java/com/eaglegenomics/simlims/core/Group.java
+++ b/core/src/main/java/com/eaglegenomics/simlims/core/Group.java
@@ -49,7 +49,7 @@ public class Group implements Serializable, Comparable<Group>, Deletable, Identi
   private Set<User> users = new HashSet<>();
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long groupId = Group.UNSAVED_ID;
 
   @Override

--- a/core/src/main/java/com/eaglegenomics/simlims/core/Note.java
+++ b/core/src/main/java/com/eaglegenomics/simlims/core/Note.java
@@ -38,7 +38,7 @@ public class Note implements Serializable, Comparable<Note>, Identifiable {
   public static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long noteId = Note.UNSAVED_ID;
 
   @Column(nullable = false)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractBox.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractBox.java
@@ -30,7 +30,7 @@ public abstract class AbstractBox implements Box {
   private static final Long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long boxId = UNSAVED_ID;
   private String name;
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/BoxSize.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/BoxSize.java
@@ -40,7 +40,7 @@ public class BoxSize implements Deletable, Identifiable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "boxSizeId")
   private long id = UNSAVED_ID;
   @Column(name = "boxSizeRows")

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/BoxUse.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/BoxUse.java
@@ -17,7 +17,7 @@ public class BoxUse implements Aliasable, Deletable, Serializable {
 
   private static final long UNSAVED_ID = 0L;
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "boxUseId")
   private long id = UNSAVED_ID;
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Experiment.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Experiment.java
@@ -147,7 +147,7 @@ public class Experiment implements Comparable<Experiment>, Nameable, ChangeLogga
   private String description;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long experimentId = UNSAVED_ID;
 
   @ManyToMany(targetEntity = KitImpl.class)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Index.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Index.java
@@ -96,7 +96,7 @@ public class Index implements Deletable, Nameable, Serializable {
   private String realSequences;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long indexId = UNSAVED_ID;
 
   public IndexFamily getFamily() {

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/KitImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/KitImpl.java
@@ -58,7 +58,7 @@ public class KitImpl implements Kit {
   private static final long serialVersionUID = 1L;
   public static final Long UNSAVED_ID = 0L;
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long kitId = KitImpl.UNSAVED_ID;
   private String identificationBarcode;
   private String locationBarcode;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PartitionQCType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PartitionQCType.java
@@ -18,7 +18,7 @@ public class PartitionQCType implements Deletable, Identifiable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long partitionQcTypeId = UNSAVED_ID;
 
   @Column(nullable = false)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Printer.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Printer.java
@@ -64,7 +64,7 @@ public class Printer implements Deletable, Serializable {
   private String name;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long printerId = UNSAVED_ID;
 
   private double width;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Run.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Run.java
@@ -134,7 +134,7 @@ public abstract class Run
   private Collection<Note> notes = new HashSet<>();
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long runId = UNSAVED_ID;
 
   @ManyToOne(targetEntity = InstrumentImpl.class)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/RunLibraryQcStatus.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/RunLibraryQcStatus.java
@@ -18,7 +18,7 @@ public class RunLibraryQcStatus implements Deletable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long statusId = UNSAVED_ID;
 
   private String description;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/ServiceRecord.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/ServiceRecord.java
@@ -31,7 +31,7 @@ public class ServiceRecord implements Serializable, Deletable, Attachable {
   private static final long UNSAVED_ID = 0L;
   
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long recordId = ServiceRecord.UNSAVED_ID;
 
   @ManyToOne(targetEntity = InstrumentImpl.class)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Submission.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Submission.java
@@ -64,7 +64,7 @@ public class Submission implements Comparable<Submission>, Deletable, Serializab
   private Set<Experiment> experiments = new HashSet<>();
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long submissionId = UNSAVED_ID;
 
   @Temporal(TemporalType.DATE)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Assay.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Assay.java
@@ -18,7 +18,7 @@ public class Assay implements Aliasable, Deletable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long assayId;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/AssayTest.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/AssayTest.java
@@ -28,7 +28,7 @@ public class AssayTest implements Aliasable, Deletable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long testId = UNSAVED_ID;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/AttachmentCategory.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/AttachmentCategory.java
@@ -18,7 +18,7 @@ public class AttachmentCategory implements Aliasable, Deletable, Serializable {
   private static final long UNSAVED_ID = 0;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long categoryId = UNSAVED_ID;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/FileAttachment.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/FileAttachment.java
@@ -24,7 +24,7 @@ public class FileAttachment implements Identifiable, Serializable {
   private static final long UNSAVED_ID = 0;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long attachmentId = UNSAVED_ID;
   private String filename;
   private String path;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/InstrumentImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/InstrumentImpl.java
@@ -64,7 +64,7 @@ public class InstrumentImpl implements Instrument {
   private static final Long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "instrumentId")
   private long id = InstrumentImpl.UNSAVED_ID;
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAliquot.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAliquot.java
@@ -90,7 +90,7 @@ public class LibraryAliquot extends AbstractBoxable
   public static final Long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long aliquotId = LibraryAliquot.UNSAVED_ID;
 
   @Column(nullable = false)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryImpl.java
@@ -104,7 +104,7 @@ public class LibraryImpl extends AbstractBoxable implements Library {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long libraryId = UNSAVED_ID;
 
   @Column(nullable = false)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryTemplate.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryTemplate.java
@@ -41,7 +41,7 @@ public class LibraryTemplate implements Serializable, Deletable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long libraryTemplateId = UNSAVED_ID;
 
   String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Metric.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Metric.java
@@ -29,7 +29,7 @@ public class Metric implements Aliasable, Deletable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long metricId;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PartitionImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PartitionImpl.java
@@ -58,7 +58,7 @@ public class PartitionImpl implements Partition {
   private static final long serialVersionUID = 1L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "partitionId")
   private long id = UNSAVED_ID;
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Pipeline.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Pipeline.java
@@ -18,7 +18,7 @@ public class Pipeline implements Aliasable, Deletable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long pipelineId = UNSAVED_ID;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoreVersion.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoreVersion.java
@@ -17,7 +17,7 @@ public class PoreVersion implements Serializable, Aliasable {
   private static final long UNSAVED_ID = 0;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long poreVersionId = UNSAVED_ID;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ProjectImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ProjectImpl.java
@@ -122,7 +122,7 @@ public class ProjectImpl implements Project {
 
   @Id
   @Column(name = "projectId")
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id = UNSAVED_ID;
 
   @OneToMany(targetEntity = StudyImpl.class, fetch = FetchType.LAZY, mappedBy = "project", cascade = CascadeType.REMOVE)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Requisition.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/Requisition.java
@@ -46,7 +46,7 @@ public class Requisition implements Aliasable, Attachable, ChangeLoggable, Delet
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long requisitionId = UNSAVED_ID;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleImpl.java
@@ -96,7 +96,7 @@ public class SampleImpl extends AbstractBoxable implements Sample {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long sampleId = UNSAVED_ID;
 
   @ManyToOne(targetEntity = ProjectImpl.class)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencerPartitionContainerImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencerPartitionContainerImpl.java
@@ -80,7 +80,7 @@ public class SequencerPartitionContainerImpl implements SequencerPartitionContai
   public static final int DEFAULT_PARTITION_LIMIT = 8;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long containerId = SequencerPartitionContainerImpl.UNSAVED_ID;
 
   /**

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencingContainerModel.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencingContainerModel.java
@@ -30,7 +30,7 @@ public class SequencingContainerModel implements Aliasable, Deletable, Serializa
   private static final long UNSAVED_ID = 0;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long sequencingContainerModelId = UNSAVED_ID;
 
   private String alias;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StorageLabel.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StorageLabel.java
@@ -18,7 +18,7 @@ public class StorageLabel implements Deletable, Identifiable, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long labelId = UNSAVED_ID;
 
   private String label;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StorageLocation.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StorageLocation.java
@@ -81,7 +81,7 @@ public class StorageLocation implements Serializable, Aliasable, ChangeLoggable,
 
   @Id
   @Column(name = "locationId")
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id = UNSAVED_ID;
 
   @ManyToOne

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StorageLocationMap.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StorageLocationMap.java
@@ -18,7 +18,7 @@ public class StorageLocationMap implements Deletable, Identifiable, Serializable
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long mapId = UNSAVED_ID;
   private String filename;
   private String description;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StudyImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StudyImpl.java
@@ -74,7 +74,7 @@ public class StudyImpl implements Study {
   private Collection<Experiment> experiments = new HashSet<>();
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long studyId = StudyImpl.UNSAVED_ID;
 
   @Transient

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/TargetedSequencing.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/TargetedSequencing.java
@@ -33,7 +33,7 @@ public class TargetedSequencing implements Deletable, Identifiable, Serializable
   public static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long targetedSequencingId = UNSAVED_ID;
 
   @Column(nullable = false)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/UserImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/UserImpl.java
@@ -75,7 +75,7 @@ public class UserImpl implements User, Serializable {
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long userId = UserImpl.UNSAVED_ID;
   private String fullName;
   private String loginName;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/kit/KitDescriptor.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/kit/KitDescriptor.java
@@ -83,7 +83,7 @@ public class KitDescriptor implements Serializable, ChangeLoggable, Deletable, I
   private static final Long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long kitDescriptorId = KitDescriptor.UNSAVED_ID;
   private String name;
   private Integer version;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/SequencingOrderSummaryView.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/SequencingOrderSummaryView.java
@@ -34,8 +34,6 @@ public class SequencingOrderSummaryView implements Serializable {
   @Id
   private String orderSummaryId;
 
-  private String loadedPartitionsId;
-
   @ManyToOne
   @JoinColumn(name = "poolId")
   private ListPoolView pool;
@@ -49,6 +47,7 @@ public class SequencingOrderSummaryView implements Serializable {
   private SequencingParameters parameters;
 
   private int requested;
+  private int loaded;
   private String description;
   private String purpose;
 
@@ -62,18 +61,6 @@ public class SequencingOrderSummaryView implements Serializable {
   @OneToMany
   @JoinColumn(name = "noContainerModelId")
   private Set<SequencingOrderPartitionView> noContainerModelPartitions;
-
-  @ElementCollection
-  @CollectionTable(name = "SequencingOrderLoadedPartitionView", joinColumns = {
-      @JoinColumn(name = "loadedPartitionsId", referencedColumnName = "loadedPartitionsId") })
-  @Column(name = "partitionId")
-  private Set<Long> loadedPartitions;
-
-  @ElementCollection
-  @CollectionTable(name = "SequencingOrderLoadedPartitionView", joinColumns = {
-      @JoinColumn(name = "noContainerModelId", referencedColumnName = "loadedPartitionsId") })
-  @Column(name = "partitionId")
-  private Set<Long> noContainerModelLoadedPartitions;
 
   @OneToOne
   @PrimaryKeyJoinColumn
@@ -89,14 +76,6 @@ public class SequencingOrderSummaryView implements Serializable {
 
   public void setId(String id) {
     this.orderSummaryId = id;
-  }
-
-  public String getLoadedPartitionsId() {
-    return loadedPartitionsId;
-  }
-
-  public void setLoadedPartitionsId(String loadedPartitionsId) {
-    this.loadedPartitionsId = loadedPartitionsId;
   }
 
   public ListPoolView getPool() {
@@ -179,22 +158,6 @@ public class SequencingOrderSummaryView implements Serializable {
     this.noContainerModelPartitions = noContainerModelPartitions;
   }
 
-  public Set<Long> getLoadedPartitions() {
-    return loadedPartitions;
-  }
-
-  public void setLoadedPartitions(Set<Long> loadedPartitions) {
-    this.loadedPartitions = loadedPartitions;
-  }
-
-  public Set<Long> getNoContainerModelLoadedPartitions() {
-    return noContainerModelLoadedPartitions;
-  }
-
-  public void setNoContainerModelLoadedPartitions(Set<Long> noContainerModelLoadedPartitions) {
-    this.noContainerModelLoadedPartitions = noContainerModelLoadedPartitions;
-  }
-
   public SequencingOrderNoContainerModelFulfillmentView getNoContainerModelFulfillmentView() {
     return noContainerModelFulfillmentView;
   }
@@ -224,16 +187,11 @@ public class SequencingOrderSummaryView implements Serializable {
   }
 
   public int getLoaded() {
-    Set<Long> effectivePartitions;
-    if (getContainerModel() == null) {
-      effectivePartitions = noContainerModelLoadedPartitions;
-    } else {
-      effectivePartitions = loadedPartitions;
-    }
-    if (effectivePartitions == null) {
-      return 0;
-    }
-    return effectivePartitions.size();
+    return loaded;
+  }
+
+  public void setLoaded(int loaded) {
+    this.loaded = loaded;
   }
 
   public int get(HealthType health) {

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/qc/QC.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/qc/QC.java
@@ -73,7 +73,7 @@ public abstract class QC implements Deletable, Serializable, Comparable<QC>, Ide
   private Date lastModified;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long qcId = QC.UNSAVED_ID;
 
   private BigDecimal results;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/LibrarySelectionType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/LibrarySelectionType.java
@@ -53,7 +53,7 @@ public class LibrarySelectionType implements Comparable<LibrarySelectionType>, D
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long librarySelectionTypeId = LibrarySelectionType.UNSAVED_ID;
 
   @Column(nullable = false, unique = true)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/LibraryStrategyType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/LibraryStrategyType.java
@@ -53,7 +53,7 @@ public class LibraryStrategyType implements Comparable<LibraryStrategyType>, Del
   private static final Long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long libraryStrategyTypeId = LibraryStrategyType.UNSAVED_ID;
 
   @Column(nullable = false, unique = true)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/LibraryType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/LibraryType.java
@@ -46,7 +46,7 @@ public class LibraryType implements Comparable<LibraryType>, Deletable, Identifi
   public static final Long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long libraryTypeId = LibraryType.UNSAVED_ID;
 
   @Column(nullable = false)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/QcType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/QcType.java
@@ -68,7 +68,7 @@ public class QcType implements Comparable<QcType>, Serializable, Aliasable, Dele
   private static final long UNSAVED_ID = 0L;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long qcTypeId = QcType.UNSAVED_ID;
   private String name;
   private String description;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/TissuePieceType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/TissuePieceType.java
@@ -55,7 +55,7 @@ public class TissuePieceType implements Deletable, Identifiable, Serializable {
   private String name;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long tissuePieceTypeId = TissuePieceType.UNSAVED_ID;
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/workflow/impl/ProgressImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/workflow/impl/ProgressImpl.java
@@ -39,7 +39,7 @@ public class ProgressImpl implements Progress {
   private static final long UNSAVED_ID = 0;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long workflowProgressId = UNSAVED_ID;
 
   @Enumerated(EnumType.STRING)

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTransferService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTransferService.java
@@ -142,6 +142,8 @@ public class DefaultTransferService extends AbstractSaveService<Transfer> implem
     }
     String position = item.getItem().getBoxPosition();
     loadChildEntity(item.getItem(), setter, service);
+    // detach to prevent Hibernate from prematurely detecting changes in this entity
+    transferStore.detachEntity(item.getItem());
     setBoxPosition(item, box, position, positionConstructor, positionSetter);
   }
 

--- a/miso-web/src/it/resources/it-context.xml
+++ b/miso-web/src/it/resources/it-context.xml
@@ -1,26 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2012. The Genome Analysis Centre, Norwich, UK
-  ~ MISO project contacts: Robert Davey, Mario Caccamo @ TGAC
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses/>.
-  ~
-  ~ **********************************************************************
--->
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans 
@@ -28,7 +6,7 @@
   
   <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource" />
     <property name="packagesToScan">
       <list>
@@ -53,7 +31,7 @@
     <property name="dataSource" ref="dataSource"/>
   </bean>
   
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
     <property name="dataSource" ref="dataSource"/>
   </bean>

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
@@ -197,7 +197,7 @@ public class ConstantsController {
     }
   }
 
-  @GetMapping(path = "/constants.js")
+  @GetMapping(path = "/constants.js", produces = "application/javascript")
   @ResponseBody
   public synchronized ResponseEntity<String> constantsScript(HttpServletResponse response, final UriComponentsBuilder uriBuilder)
       throws IOException {

--- a/miso-web/src/main/webapp/WEB-INF/db-config.xml
+++ b/miso-web/src/main/webapp/WEB-INF/db-config.xml
@@ -35,7 +35,7 @@
   default-autowire="byName">
 
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource" />
     <property name="packagesToScan">
       <list>
@@ -55,7 +55,7 @@
   <bean id="jpaDialect" class="org.springframework.orm.jpa.vendor.HibernateJpaDialect" />
   <bean class="org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor" />
 
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory" />
     <property name="dataSource" ref="dataSource" />
   </bean>
@@ -71,11 +71,8 @@
   <!-- Spring JDBC TEMPLATES STUFF -->
   <bean name="interfaceTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
     <property name="dataSource" ref="dataSource" />
-    <property name="nativeJdbcExtractor" ref="nativeJdbcExtractor" />
   </bean>
 
   <bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" lazy-init="true" />
-
-  <bean name="nativeJdbcExtractor" class="org.springframework.jdbc.support.nativejdbc.CommonsDbcpNativeJdbcExtractor" />
 
 </beans>

--- a/miso-web/src/main/webapp/WEB-INF/db-config.xml
+++ b/miso-web/src/main/webapp/WEB-INF/db-config.xml
@@ -1,26 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2012. The Genome Analysis Centre, Norwich, UK
-  ~ MISO project contacts: Robert Davey @ TGAC
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses/>.
-  ~
-  ~ **********************************************************************
--->
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:tx="http://www.springframework.org/schema/tx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:jee="http://www.springframework.org/schema/jee" xmlns:context="http://www.springframework.org/schema/context"

--- a/miso-web/src/main/webapp/WEB-INF/log4j2.miso.properties
+++ b/miso-web/src/main/webapp/WEB-INF/log4j2.miso.properties
@@ -20,6 +20,8 @@ appender.rolling.strategy.max = 4
 #logger.hibernateSql.level = debug
 #logger.hibernateType.name = org.hibernate.type.descriptor.sql
 #logger.hibernateType.level = trace
+logger.hibernateDeprecation.name = org.hibernate.orm.deprecation
+logger.hibernateDeprecation.level = error
 
 rootLogger.level = info
 rootLogger.appenderRefs = rolling

--- a/miso-web/src/main/webapp/WEB-INF/web.xml
+++ b/miso-web/src/main/webapp/WEB-INF/web.xml
@@ -44,17 +44,6 @@
     <filter-name>encoding-filter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
-  <!-- logging : REMOVED SO THAT MisoAppListener CAN LOAD THE PROPERTIES INCLUDING ANY PLACEHOLDERS -->
-  <!--
-    <context-param>
-    <param-name>log4jConfigLocation</param-name>
-    <param-value>/WEB-INF/log4j.miso.properties</param-value>
-    </context-param>
-  -->
-
-  <listener>
-    <listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>
-  </listener>
 
   <!-- JNDI database config -->
   <resource-ref>

--- a/pom.xml
+++ b/pom.xml
@@ -447,17 +447,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <!-- Required to make Hibernate 4 logging compatible with log4j2 -->
-        <groupId>org.jboss.logging</groupId>
-        <artifactId>jboss-logging</artifactId>
-        <version>3.4.1.Final</version>
-      </dependency>
-      <!--<dependency>
-        <groupId>org.hibernate.javax.persistence</groupId>
-        <artifactId>hibernate-jpa-2.1-api</artifactId>
-        <version>1.0.2.Final</version>
-      </dependency>-->
-      <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,10 +111,10 @@
   </distributionManagement>
   <properties>
     <skipUTs>${skipTests}</skipUTs>
-    <spring-version>4.3.24.RELEASE</spring-version>
+    <spring-version>5.3.21</spring-version>
     <spring-security-version>5.0.12.RELEASE</spring-security-version>
     <spring-integration-version>4.3.20.RELEASE</spring-integration-version>
-    <hibernate.version>4.2.21.Final</hibernate.version>
+    <hibernate.version>5.6.9.Final</hibernate.version>
     <joda-time.version>2.9</joda-time.version>
     <hamcrest.version>1.3</hamcrest.version>
     <junit.version>4.12</junit.version>
@@ -259,6 +259,11 @@
         <groupId>io.prometheus.jmx</groupId>
         <artifactId>collector</artifactId>
         <version>${prometheus.jmx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -447,11 +452,11 @@
         <artifactId>jboss-logging</artifactId>
         <version>3.4.1.Final</version>
       </dependency>
-      <dependency>
+      <!--<dependency>
         <groupId>org.hibernate.javax.persistence</groupId>
-        <artifactId>hibernate-jpa-2.0-api</artifactId>
-        <version>1.0.1.Final</version>
-      </dependency>
+        <artifactId>hibernate-jpa-2.1-api</artifactId>
+        <version>1.0.2.Final</version>
+      </dependency>-->
       <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>

--- a/sqlstore/pom.xml
+++ b/sqlstore/pom.xml
@@ -32,6 +32,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
@@ -55,12 +59,6 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <type>jar</type>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <!-- Required to get Spring logging into Log4j2 -->

--- a/sqlstore/src/it/resources/db-it-context.xml
+++ b/sqlstore/src/it/resources/db-it-context.xml
@@ -1,37 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2012. The Genome Analysis Centre, Norwich, UK
-  ~ MISO project contacts: Robert Davey, Mario Caccamo @ TGAC
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO. If not, see <http://www.gnu.org/licenses/>.
-  ~
-  ~ **********************************************************************
--->
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:tx="http://www.springframework.org/schema/tx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:jee="http://www.springframework.org/schema/jee" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans 
                            http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
                            http://www.springframework.org/schema/tx 
-                           http://www.springframework.org/schema/tx/spring-tx-3.2.xsd
-                           http://www.springframework.org/schema/jee 
-                           http://www.springframework.org/schema/jee/spring-jee-3.2.xsd 
-                           http://www.springframework.org/schema/context 
-                           http://www.springframework.org/schema/context/spring-context.xsd"
+                           http://www.springframework.org/schema/tx/spring-tx-3.2.xsd"
   default-autowire="byName">
 
   <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />
@@ -43,7 +16,7 @@
     <property name="password" value="${miso.it.mysql.pw}" />
   </bean>
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource" />
     <property name="packagesToScan">
       <list>
@@ -66,7 +39,7 @@
   <bean name="interfaceTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
     <property name="dataSource" ref="dataSource" />
   </bean>
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory" />
     <property name="dataSource" ref="dataSource" />
   </bean>

--- a/sqlstore/src/it/resources/log4j2-test.properties
+++ b/sqlstore/src/it/resources/log4j2-test.properties
@@ -20,6 +20,8 @@ logger.transactionContext.level = warn
 #logger.hibernateSql.level = debug
 #logger.hibernateType.name = org.hibernate.type.descriptor.sql
 #logger.hibernateType.level = trace
+logger.hibernateDeprecation.name = org.hibernate.orm.deprecation
+logger.hibernateDeprecation.level = error
 
 rootLogger.level = error
 rootLogger.appenderRefs = console

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/AliasTrackingCriteria.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/AliasTrackingCriteria.java
@@ -185,6 +185,12 @@ public class AliasTrackingCriteria implements Criteria {
   }
 
   @Override
+  public Criteria addQueryHint(String s) {
+    backingCriteria.addQueryHint(s);
+    return this;
+  }
+
+  @Override
   public Criteria setFetchMode(String associationPath, FetchMode mode) throws HibernateException {
     backingCriteria.setFetchMode(associationPath, mode);
     return this;

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunPartitionAliquotDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunPartitionAliquotDao.java
@@ -130,7 +130,8 @@ public class HibernateRunPartitionAliquotDao implements RunPartitionAliquotDao {
   private List<Object[]> queryIds(String additionalQuery, long[] parameters) {
     return queryIds(additionalQuery, query -> {
       for (int i = 0; i < parameters.length; i++) {
-        query.setLong(i, parameters[i]);
+        // parameters indices start at 1, but parameters array starts at 0
+        query.setLong(i+1, parameters[i]);
       }
     });
   }

--- a/sqlstore/src/test/resources/log4j2-test.properties
+++ b/sqlstore/src/test/resources/log4j2-test.properties
@@ -20,6 +20,8 @@ logger.transactionContext.level = warn
 #logger.hibernateSql.level = debug
 #logger.hibernateType.name = org.hibernate.type.descriptor.sql
 #logger.hibernateType.level = trace
+logger.hibernateDeprecation.name = org.hibernate.orm.deprecation
+logger.hibernateDeprecation.level = error
 
 rootLogger.level = error
 rootLogger.appenderRefs = console

--- a/sqlstore/src/test/resources/real-db-test-context.xml
+++ b/sqlstore/src/test/resources/real-db-test-context.xml
@@ -1,42 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2012. The Genome Analysis Centre, Norwich, UK
-  ~ MISO project contacts: Robert Davey, Mario Caccamo @ TGAC
-  ~ **********************************************************************
-  ~
-  ~ This file is part of MISO.
-  ~
-  ~ MISO is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ (at your option) any later version.
-  ~
-  ~ MISO is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with MISO.  If not, see <http://www.gnu.org/licenses/>.
-  ~
-  ~ **********************************************************************
-  -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:tx="http://www.springframework.org/schema/tx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:jee="http://www.springframework.org/schema/jee"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans 
                            http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
                            http://www.springframework.org/schema/tx 
-                           http://www.springframework.org/schema/tx/spring-tx-3.2.xsd
-                           http://www.springframework.org/schema/jee 
-                           http://www.springframework.org/schema/jee/spring-jee-3.2.xsd 
-                           http://www.springframework.org/schema/context 
-                           http://www.springframework.org/schema/context/spring-context.xsd"
+                           http://www.springframework.org/schema/tx/spring-tx-3.2.xsd"
        default-autowire="byName">
   
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource" />
     <property name="packagesToScan">
       <list>
@@ -72,7 +44,7 @@
   <bean name="interfaceTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
     <property name="dataSource" ref="dataSource"/>
   </bean>
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
     <property name="dataSource" ref="dataSource"/>
   </bean>


### PR DESCRIPTION
Some notes...

* Disabled logging of Hibernate deprecation warnings. The Hibernate criteria API has long been deprecated in favour of the JPA criteria API. This is unfortunate, since the Hibernate criteria API was much much better... MISO uses the Hibernate criteria API extensively, and Hibernate now logs a warning every time you invoke it. If we ever update to the JPA criteria API, it will take months of effort.
* There was some remaining log4j1 config that I had to rip out. I tested to ensure that logging to `miso_debug.log` is still working as before
* Default behaviour of `GenerationType.AUTO` used to be `IDENTITY`, but that changed, so I had to change everything to specify `IDENTITY`

Jira ticket or GitHub issue: https://github.com/miso-lims/miso-lims/issues/2684

- [x] Includes a change file
