### PR TITLE
[GLT-3968] fixed printing sample labels with received date

### DIFF
--- a/changes/fix_print_receiptTime.md
+++ b/changes/fix_print_receiptTime.md
@@ -1,0 +1,1 @@
+Error when printing sample labels that include the received date

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/transfer/Transfer.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/transfer/Transfer.java
@@ -25,7 +25,6 @@ import com.eaglegenomics.simlims.core.User;
 import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
 import uk.ac.bbsrc.tgac.miso.core.data.ChangeLoggable;
 import uk.ac.bbsrc.tgac.miso.core.data.Deletable;
-import uk.ac.bbsrc.tgac.miso.core.data.Identifiable;
 import uk.ac.bbsrc.tgac.miso.core.data.Lab;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LabImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
@@ -33,7 +32,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.TransferChangeLog;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 
 @Entity
-public class Transfer implements Identifiable, ChangeLoggable, Deletable, Serializable {
+public class Transfer implements ChangeLoggable, Deletable, Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/transfer/ListTransferView.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/transfer/ListTransferView.java
@@ -36,7 +36,7 @@ public class ListTransferView implements Identifiable, Serializable {
   @Id
   private long transferId;
 
-  @Temporal(TemporalType.DATE)
+  @Temporal(TemporalType.TIMESTAMP)
   private Date transferTime;
 
   @ManyToOne(targetEntity = LabImpl.class)
@@ -199,7 +199,8 @@ public class ListTransferView implements Identifiable, Serializable {
         + countItems(getLibraryAliquots(), predicate) + countItems(getPools(), predicate);
   }
 
-  private static long countItems(Collection<? extends ListTransferViewItem> items, Predicate<ListTransferViewItem> predicate) {
+  private static long countItems(Collection<? extends ListTransferViewItem> items,
+      Predicate<ListTransferViewItem> predicate) {
     return items.stream().filter(predicate).count();
   }
 

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -4164,7 +4164,7 @@ public class Dtos {
   public static ListTransferViewDto asDto(@Nonnull ListTransferView from) {
     ListTransferViewDto to = new ListTransferViewDto();
     setLong(to::setId, from.getId(), false);
-    setDateString(to::setTransferTime, from.getTransferTime());
+    setDateTimeString(to::setTransferTime, from.getTransferTime());
     setId(to::setSenderLabId, from.getSenderLab());
     setString(to::setSenderLabLabel, maybeGetProperty(from.getSenderLab(), Lab::getAlias));
     setId(to::setSenderGroupId, from.getSenderGroup());

--- a/miso-web/src/main/webapp/scripts/list.js
+++ b/miso-web/src/main/webapp/scripts/list.js
@@ -981,6 +981,21 @@ ListUtils = (function ($) {
           return data;
         };
       },
+      dateWithTimeTooltip: function (data, type, full) {
+        if (type === "display" && data) {
+          return (
+            '<div class="tooltip">' +
+            "<span>" +
+            data.split(" ")[0] +
+            "</span>" +
+            '<span class="tooltiptext">' +
+            data +
+            "</span>" +
+            "</div>"
+          );
+        }
+        return data;
+      },
     },
     createBoxField: {
       property: "createBox",

--- a/miso-web/src/main/webapp/scripts/list_samples.js
+++ b/miso-web/src/main/webapp/scripts/list_samples.js
@@ -303,21 +303,7 @@ ListTarget.sample = (function () {
         {
           sTitle: "Modified",
           mData: "lastModified",
-          mRender: function (data, type, full) {
-            if (type !== "display") {
-              return data;
-            }
-            return (
-              '<div class="tooltip">' +
-              "<span>" +
-              data.split(" ")[0] +
-              "</span>" +
-              '<span class="tooltiptext">' +
-              data +
-              "</span>" +
-              "</div>"
-            );
-          },
+          mRender: ListUtils.render.dateWithTimeTooltip,
           include: Constants.isDetailedSample,
           iSortPriority: 2,
         },

--- a/miso-web/src/main/webapp/scripts/list_transfer.js
+++ b/miso-web/src/main/webapp/scripts/list_transfer.js
@@ -63,6 +63,7 @@ ListTarget.transfer = (function () {
         {
           sTitle: "Transfer Time",
           mData: "transferTime",
+          mRender: ListUtils.render.dateWithTimeTooltip,
         },
         {
           sTitle: "Received",


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-3968

- [x] Includes a change file

`TemporalType.DATE` gets populated as `java.sql.Date`, which is a subclass of `java.util.Date` that throws `UnsupportedOperationException` on `toInstant()`. We use `LocalDate` for date-only types elsewhere to avoid this and other problems, but in this case it should actually be a timestamp