### PR TITLE
[GLT-3973] removed old/unnecessary library from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,6 @@ COPY --from=builder /miso-lims/miso-web/src/main/resources/miso.properties  ${CA
 COPY --from=builder /miso-lims/miso-web/src/main/resources/security.properties /storage/miso/
 COPY --from=builder /miso-lims/miso-web/src/main/resources/submission.properties /storage/miso/
 
-COPY --from=builder /miso-lims/miso-web/target/ROOT/WEB-INF/lib/mysql-connector-java-*.jar ${CATALINA_HOME}/lib/
 COPY --from=builder /miso-lims/miso-web/target/ROOT.war ${CATALINA_HOME}/webapps/
 
 ENV MISO_DB_USER tgaclims


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-3973

- [ ] Includes a change file (n/a)

Tested with the latest version of Docker (Mac)
