### PR TITLE
[GLT-4084] support range metrics on Run-Library metrics page

### DIFF
--- a/changes/add_between_runLibMetric.md
+++ b/changes/add_between_runLibMetric.md
@@ -1,0 +1,1 @@
+Support for metrics with a range threshold on Run-Library Metrics page

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/dashi/RunLibraryQcTableRequestMetricDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/dashi/RunLibraryQcTableRequestMetricDto.java
@@ -7,6 +7,7 @@ public class RunLibraryQcTableRequestMetricDto {
   private String title;
   private String thresholdType;
   private double threshold;
+  private double threshold2;
   private Double value;
 
   public String getTitle() {
@@ -32,6 +33,15 @@ public class RunLibraryQcTableRequestMetricDto {
 
   public void setThreshold(double threshold) {
     this.threshold = threshold;
+  }
+
+  @JsonProperty(value = "threshold_2")
+  public double getThreshold2() {
+    return threshold2;
+  }
+
+  public void setThreshold2(double threshold2) {
+    this.threshold2 = threshold2;
   }
 
   public Double getValue() {

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/dashi/RunLibraryQcTableRowMetricDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/dashi/RunLibraryQcTableRowMetricDto.java
@@ -5,6 +5,7 @@ public class RunLibraryQcTableRowMetricDto {
   private String title;
   private String thresholdType;
   private double threshold;
+  private double threshold2;
   private Double value;
 
   public static RunLibraryQcTableRowMetricDto fromRequestDto(RunLibraryQcTableRequestMetricDto from) {
@@ -12,6 +13,7 @@ public class RunLibraryQcTableRowMetricDto {
     to.setTitle(from.getTitle());
     to.setThresholdType(from.getThresholdType());
     to.setThreshold(from.getThreshold());
+    to.setThreshold2(from.getThreshold2());
     to.setValue(from.getValue());
     return to;
   }
@@ -38,6 +40,14 @@ public class RunLibraryQcTableRowMetricDto {
 
   public void setThreshold(double threshold) {
     this.threshold = threshold;
+  }
+
+  public double getThreshold2() {
+    return threshold2;
+  }
+
+  public void setThreshold2(double threshold2) {
+    this.threshold2 = threshold2;
   }
 
   public Double getValue() {

--- a/miso-web/src/main/webapp/scripts/runLibraryMetrics_ajax.js
+++ b/miso-web/src/main/webapp/scripts/runLibraryMetrics_ajax.js
@@ -152,21 +152,21 @@ var RunLibraryMetrics = (function ($) {
   };
 
   function displayThreshold(metric) {
-    return $("<div>").text(
-      " (threshold: " + makeThresholdTypeLabel(metric) + " " + metric.threshold + ")"
-    );
+    return $("<div>").text(" (threshold: " + makeThresholdTypeLabel(metric) + ")");
   }
 
   function makeThresholdTypeLabel(metric) {
     switch (metric.thresholdType) {
       case "gt":
-        return ">";
+        return "> " + metric.threshold;
       case "ge":
-        return ">=";
+        return ">= " + metric.threshold;
       case "lt":
-        return "<";
+        return "< " + metric.threshold;
       case "le":
-        return "<=";
+        return "<= " + metric.threshold;
+      case "between":
+        return "between " + metric.threshold + " and " + metric.threshold2;
       default:
         throw new Error("Unknown thresholdType: metric.thresholdType");
     }
@@ -182,6 +182,8 @@ var RunLibraryMetrics = (function ($) {
         return metric.value < metric.threshold;
       case "le":
         return metric.value <= metric.threshold;
+      case "between":
+        return metric.value >= metric.threshold && metric.value <= metric.threshold2;
       default:
         throw new Error("Unknown thresholdType: metric.thresholdType");
     }


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4084

- [x] Includes a change file

Using `minimum` and/or `maximum` fields as in other places would have been nicer than `threshold` and `threshold2`, but this way is backwards compatible. This doesn't require Dashi changes, and we don't need to do Dashi, Dimsum, and MISO releases all at the same time.