### PR TITLE
[GLT-4190] Update HibernateRunPartitionDao to JPA Criteria

### DIFF
--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/RunPartitionStore.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/RunPartitionStore.java
@@ -6,7 +6,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.RunPartition;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerPartitionContainer;
 
-public interface RunPartitionStore {
+public interface RunPartitionStore extends ProviderDao<RunPartition> {
 
   public RunPartition get(long runId, long partitionId) throws IOException;
 


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4190

- [ ] Includes a change file

Refactored to extend HibernateProviderDao/ProviderDao for now. RunPartition does not extend Identifiable and HibernateRunPartitionDao cannot be refactored to extend HibernateSaveDao. 