### PR TITLE
removed jdom dependency; updated j2html

### DIFF
--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -173,10 +173,6 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
       <dependency>
         <groupId>com.j2html</groupId>
         <artifactId>j2html</artifactId>
-        <version>1.4.0</version>
+        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.opencsv</groupId>
@@ -442,11 +442,6 @@
         <groupId>jakarta.annotation</groupId>
         <artifactId>jakarta.annotation-api</artifactId>
         <version>3.0.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jdom</groupId>
-        <artifactId>jdom</artifactId>
-        <version>1.1</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
Jira ticket or GitHub issue: https://github.com/miso-lims/miso-lims/security/dependabot/12

- [ ] Includes a change file (n/a)

I think j2html replaced jdom in MISO, but either way jdom doesn't seem to be used anymore