### PR TITLE
[#3019] fixed bulk QC pages showing wrong items after saving

### DIFF
--- a/changes/fix_savedQc_dsiplay.md
+++ b/changes/fix_savedQc_dsiplay.md
@@ -1,0 +1,1 @@
+The bulk Add/Edit QCs pages were displaying the wrong items after saving

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateContainerQcDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateContainerQcDao.java
@@ -8,8 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerPartitionContainer;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SequencerPartitionContainerImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.SequencerPartitionContainerImpl_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.ContainerQC;
+import uk.ac.bbsrc.tgac.miso.core.data.qc.ContainerQC_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.QcCorrespondingField;
 import uk.ac.bbsrc.tgac.miso.persistence.ContainerQcStore;
 
@@ -32,7 +32,7 @@ public class HibernateContainerQcDao extends HibernateQcStore<ContainerQC> imple
 
   @Override
   public String getIdProperty() {
-    return SequencerPartitionContainerImpl_.CONTAINER_ID;
+    return ContainerQC_.QC_ID;
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryQcDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryQcDao.java
@@ -8,8 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryImpl_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.LibraryQC;
+import uk.ac.bbsrc.tgac.miso.core.data.qc.LibraryQC_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.QcCorrespondingField;
 import uk.ac.bbsrc.tgac.miso.persistence.LibraryQcStore;
 
@@ -31,7 +31,7 @@ public class HibernateLibraryQcDao extends HibernateQcStore<LibraryQC> implement
 
   @Override
   public String getIdProperty() {
-    return LibraryImpl_.LIBRARY_ID;
+    return LibraryQC_.QC_ID;
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolQCDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolQCDao.java
@@ -8,8 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Pool;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.PoolQC;
+import uk.ac.bbsrc.tgac.miso.core.data.qc.PoolQC_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.QcCorrespondingField;
 import uk.ac.bbsrc.tgac.miso.persistence.PoolQcStore;
 
@@ -31,7 +31,7 @@ public class HibernatePoolQCDao extends HibernateQcStore<PoolQC> implements Pool
 
   @Override
   public String getIdProperty() {
-    return PoolImpl_.POOL_ID;
+    return PoolQC_.QC_ID;
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateQcStore.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateQcStore.java
@@ -1,7 +1,6 @@
 package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -87,17 +86,13 @@ public abstract class HibernateQcStore<T extends QC> implements QcTargetStore {
       return Collections.emptyList();
     }
 
-    QueryBuilder<? extends QualityControllable<T>, ? extends QualityControllable<T>> builder =
-        new QueryBuilder<>(currentSession(), entityClass, entityClass);
+    QueryBuilder<T, T> builder = new QueryBuilder<>(currentSession(), qcClass, qcClass);
     In<Long> inClause = builder.getCriteriaBuilder().in(builder.getRoot().get(getIdProperty()));
     for (Long id : ids) {
       inClause.value(id);
     }
     builder.addPredicate(inClause);
-
-    List<T> results = new ArrayList<>();
-    builder.getResultList().forEach(result -> results.addAll(entityClass.cast(result).getQCs()));
-    return results;
+    return builder.getResultList();
   }
 
   public abstract String getIdProperty();

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRequisitionQcDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRequisitionQcDao.java
@@ -7,9 +7,9 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.Requisition;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.Requisition_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.QcCorrespondingField;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.RequisitionQC;
+import uk.ac.bbsrc.tgac.miso.core.data.qc.RequisitionQC_;
 import uk.ac.bbsrc.tgac.miso.persistence.RequisitionQcStore;
 
 @Repository
@@ -30,7 +30,7 @@ public class HibernateRequisitionQcDao extends HibernateQcStore<RequisitionQC> i
 
   @Override
   public String getIdProperty() {
-    return Requisition_.REQUISITION_ID;
+    return RequisitionQC_.QC_ID;
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleQcDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleQcDao.java
@@ -7,9 +7,9 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl_;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.QcCorrespondingField;
 import uk.ac.bbsrc.tgac.miso.core.data.qc.SampleQC;
+import uk.ac.bbsrc.tgac.miso.core.data.qc.SampleQC_;
 import uk.ac.bbsrc.tgac.miso.persistence.SampleQcStore;
 
 @Repository
@@ -30,7 +30,7 @@ public class HibernateSampleQcDao extends HibernateQcStore<SampleQC> implements 
 
   @Override
   public String getIdProperty() {
-    return SampleImpl_.SAMPLE_ID;
+    return SampleQC_.QC_ID;
   }
 
 }


### PR DESCRIPTION
Jira ticket or GitHub issue: https://github.com/miso-lims/miso-lims/issues/3019

- [x] Includes a change file

All the QC DAOs were providing the entity ID instead of the QC ID. `HibernateQcStore#listByIdList` was supposed to be returning the QCs with the provided IDs, but instead was looking up the entities with the provided IDs and returning all of their QCs.