### PR TITLE
[GLT-4368] fixed extra space added when pasting into HandsOnTables

### DIFF
--- a/changes/fix_bulkPage_pasteSpaces.md
+++ b/changes/fix_bulkPage_pasteSpaces.md
@@ -1,0 +1,1 @@
+Additional spaces were sometimes being inserted when pasting values into bulk pages

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -1968,6 +1968,8 @@ BulkUtils = (function ($) {
             continue;
           }
           var pastedValue = data[row - coords[0].startRow][col - coords[0].startCol];
+          // remove double spaces sometimes inserted into long strings for some reason
+          pastedValue = pastedValue.replaceAll(/ +/g, " ").trim();
           if (cellSource.indexOf(pastedValue) === -1) {
             var matches = cellSource.filter(function (item) {
               return item.includes(pastedValue);
@@ -1979,8 +1981,10 @@ BulkUtils = (function ($) {
             }
             if (matches.length === 1) {
               data[row - coords[0].startRow][col - coords[0].startCol] = matches[0];
+              continue;
             }
           }
+          data[row - coords[0].startRow][col - coords[0].startCol] = pastedValue;
         }
       }
     });


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4368

- [x] Includes a change file