### PR TITLE
[GLT-4357] make Pinery use DB server timezone

### DIFF
--- a/changes/fix_pineryTimezone.md
+++ b/changes/fix_pineryTimezone.md
@@ -1,0 +1,1 @@
+Pinery-MISO will now use the database server timezone

--- a/pinery-miso/src/main/resources/pinery-miso-config.xml
+++ b/pinery-miso/src/main/resources/pinery-miso-config.xml
@@ -12,7 +12,7 @@
 
   <bean id="misoDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
     <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
-    <property name="url" value="jdbc:mysql://${miso.db.host}:${miso.db.port}/${miso.db.name}" />
+    <property name="url" value="jdbc:mysql://${miso.db.host}:${miso.db.port}/${miso.db.name}?connectionTimeZone=SERVER" />
     <property name="username" value="${miso.db.user}" />
     <property name="password" value="${miso.db.pass}" />
   </bean>


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4371

- [x] Includes a change file
