### PR TITLE
[GLT-4376] fixed sorting when printing barcodes by column

### DIFF
--- a/changes/fix_printByColumn.md
+++ b/changes/fix_printByColumn.md
@@ -1,0 +1,2 @@
+The Print Barcodes by Position action on the Edit Box page was not sorting the labels correctly when
+choosing to sort by column

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/PrinterRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/PrinterRestController.java
@@ -255,7 +255,7 @@ public class PrinterRestController extends AbstractRestController {
     if ("column".equalsIgnoreCase(request.getSortOrder())) {
       comparator = Comparator.comparing((Entry<String, BoxPosition> e) -> {
         return BoxUtils.getColumnNumber(e.getKey());
-      });
+      }).thenComparing(e -> BoxUtils.getRowNumber(e.getKey()));
     } else {
       comparator = Comparator.comparing(Entry::getKey);
     }


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4376

- [x] Includes a change file
