### PR TITLE
Remove use of volume options for bind mounts

### DIFF
--- a/.docker/demo.detailed.yml
+++ b/.docker/demo.detailed.yml
@@ -60,13 +60,9 @@ services:
       - type: bind
         source: "./detailed_sample_config/V0792__drop-inconvenient-rows.sql"
         target: "/flyway/sql/V0792__drop-inconvenient-rows.sql"
-        volume:
-          nocopy: true
       - type: bind
         source: "./detailed_sample_config/V0793__detailed_sample_data.sql"
         target: "/flyway/sql/V0793__detailed_sample_data.sql"
-        volume:
-           nocopy: true
 
   webapp:
     image: ghcr.io/miso-lims/miso-lims-webapp:${MISO_TAG}
@@ -81,8 +77,6 @@ services:
       - type: bind
         source: "./detailed_sample_config/miso.properties"
         target: "/usr/local/tomcat/conf/Catalina/localhost/miso.properties"
-        volume:
-          nocopy: true
 
 
   nginx:
@@ -94,8 +88,6 @@ services:
       - type: bind
         source: "./nginx/http.conf"
         target: "/etc/nginx/conf.d/default.conf"
-        volume:
-          nocopy: true
     links:
       - webapp
     depends_on:

--- a/.docker/demo.plain.yml
+++ b/.docker/demo.plain.yml
@@ -77,9 +77,6 @@ services:
       - type: bind
         source: "./nginx/http.conf"
         target: "/etc/nginx/conf.d/default.conf"
-        volume:
-          nocopy: 
-            true
     links:
       - webapp
     depends_on:

--- a/docker-compose.detailed.yml
+++ b/docker-compose.detailed.yml
@@ -59,13 +59,9 @@ services:
       - type: bind
         source: "./.docker/detailed_sample_config/V0792__drop-inconvenient-rows.sql"
         target: "/flyway/sql/V0792__drop-inconvenient-rows.sql"
-        volume:
-          nocopy: true
       - type: bind
         source: "./.docker/detailed_sample_config/V0793__detailed_sample_data.sql"
         target: "/flyway/sql/V0793__detailed_sample_data.sql"
-        volume:
-           nocopy: true
 
       
   webapp:
@@ -83,8 +79,6 @@ services:
       - type: bind
         source: "./.docker/detailed_sample_config/miso.properties"
         target: "/usr/local/tomcat/conf/Catalina/localhost/miso.properties"
-        volume:
-          nocopy: true
   
   nginx:
     image: nginx:1.15.12-alpine
@@ -94,8 +88,6 @@ services:
       - type: bind
         source: "./.docker/nginx/http.conf"
         target: "/etc/nginx/conf.d/default.conf"
-        volume:
-          nocopy: true
     links:
       - webapp
     depends_on:

--- a/docker-compose.plain.yml
+++ b/docker-compose.plain.yml
@@ -74,8 +74,6 @@ services:
       - type: bind
         source: "./.docker/nginx/http.conf"
         target: "/etc/nginx/conf.d/default.conf"
-        volume:
-          nocopy: true    
     links:
       - webapp
     depends_on:

--- a/docs/admin/compose-installation-guide.md
+++ b/docs/admin/compose-installation-guide.md
@@ -198,13 +198,9 @@ services:
       - type: bind
         source: "./V0792__drop-inconvenient-rows.sql"
         target: "/flyway/sql/V0792__drop-inconvenient-rows.sql"
-        volume:
-          nocopy: true
       - type: bind
         source: "./V9000__institution-custom.sql"
         target: "/flyway/sql/V9000__institution-custom.sql"
-        volume:
-           nocopy: true
 ...
 ```
 
@@ -229,8 +225,6 @@ services:
       - type: bind
         source: "./.docker/detailed_sample_config/miso.properties"
         target: "/usr/local/tomcat/conf/Catalina/localhost/miso.properties"
-        volume:
-          nocopy: true
 ...
 ```
 
@@ -356,13 +350,9 @@ services:
       - type: bind
         source: "./.docker/nginx/ssl.conf"
         target: "/etc/nginx/conf.d/default.conf"
-        volume:
-          nocopy: true
       - type: bind
         source: "./.docker/nginx/self-sign-cert.sh"
         target: "/self-sign-cert.sh"
-        volume:
-          nocopy: true
     links:
       - webapp
     depends_on:
@@ -545,13 +535,9 @@ services:
       - type: bind
         source: "./V0792__drop-inconvenient-rows.sql"
         target: "/flyway/sql/V0792__drop-inconvenient-rows.sql"
-        volume:
-          nocopy: true
       - type: bind
         source: "./V9000__institution-custom.sql"
         target: "/flyway/sql/V9000__institution-custom.sql"
-        volume:
-           nocopy: true
 
 
   webapp:
@@ -567,8 +553,6 @@ services:
       - type: bind
         source: "./miso.properties"
         target: "/usr/local/tomcat/conf/Catalina/localhost/miso.properties"
-        volume:
-          nocopy: true
       - type: bind
         source: "./files"
         target: "/storage/miso/files"
@@ -588,13 +572,9 @@ services:
       - type: bind
         source: "./nginx/ssl.conf"
         target: "/etc/nginx/conf.d/default.conf"
-        volume:
-          nocopy: true
       - type: bind
         source: "./nginx/self-sign-cert.sh"
         target: "/self-sign-cert.sh"
-        volume:
-          nocopy: true
     links:
       - webapp
     depends_on:


### PR DESCRIPTION
This is to fix the error "field VolumeOptions must not be specified" when using recent versions of Docker Compose.

Jira ticket or GitHub issue:

- [ ] Includes a change file
