### PR TITLE
[GLT-4431] API key rest tests added

### DIFF
--- a/miso-web/src/it/resources/db/migration/integration_test_data.sql
+++ b/miso-web/src/it/resources/db/migration/integration_test_data.sql
@@ -1301,5 +1301,15 @@ INSERT INTO ContactRole(contactRoleId, name) VALUES
 INSERT INTO Printer(printerId, name, driver, backend, configuration, enabled, width, height, layout) VALUES
 (1, 'Printer', 'BRADY', 'BRADY_FTP', '{"host:"127.0.0.1","pin":"0000"}', TRUE, 25, 25, '[{"element":"text", "contents":{"use":"ALIAS"}}]');
 
+INSERT INTO ApiKey(keyId, userId, apiKey, apiSecret, creator, created) VALUES
+(2, 1, "asdf", "ghjk", 1, "2025-07-08")
+ON DUPLICATE KEY UPDATE 
+  userId = 1,
+  apiKey = "asdf",
+  apiSecret = "ghjk",
+  creator = 1,
+  created = "2025-07-08";
+
+
 -- Keep this at bottom - checked to verify that script has completed and constants all loaded
 INSERT INTO AttachmentCategory(categoryId, alias) VALUES (4, 'last entry');

--- a/miso-web/src/spring-test/java/uk/ac/bbsrc/tgac/miso/webapp/springtest/ApiKeyRestControllerST.java
+++ b/miso-web/src/spring-test/java/uk/ac/bbsrc/tgac/miso/webapp/springtest/ApiKeyRestControllerST.java
@@ -1,0 +1,105 @@
+package uk.ac.bbsrc.tgac.miso.webapp.springtest;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.*;
+import org.springframework.test.context.web.WebAppConfiguration;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;
+
+import javax.ws.rs.core.MediaType;
+
+import org.checkerframework.checker.units.qual.Temperature;
+import org.junit.Before;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.*;
+
+import org.springframework.test.web.servlet.MvcResult;
+import uk.ac.bbsrc.tgac.miso.dto.Dtos;
+import uk.ac.bbsrc.tgac.miso.webapp.controller.rest.ApiKeyRestController.CreateApiKeyRequest;
+
+import org.springframework.web.servlet.View;
+
+import org.springframework.security.test.context.support.WithMockUser;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.transaction.Transactional;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.ApiKey;
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
+import com.eaglegenomics.simlims.core.User;
+import java.util.Date;
+
+
+public class ApiKeyRestControllerST extends AbstractST {
+
+  private static final String CONTROLLER_BASE = "/rest/apikeys";
+
+  @Test
+  @WithMockUser(username = "admin", password = "admin", roles = {"INTERNAL", "ADMIN"})
+  public void testCreate() throws Exception {
+    // must be admin to create an api key
+    CreateApiKeyRequest request = new CreateApiKeyRequest("testname");
+    MvcResult mvcResult =
+        getMockMvc().perform(post(CONTROLLER_BASE).contentType(MediaType.APPLICATION_JSON).content(makeJson(request)))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andReturn();
+
+    assertNotNull(mvcResult.getResponse());
+  }
+
+  @Test
+  public void testCreateFail() throws Exception {
+    CreateApiKeyRequest request = new CreateApiKeyRequest("testname");
+    getMockMvc().perform(post(CONTROLLER_BASE).contentType(MediaType.APPLICATION_JSON).content(makeJson(request)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", password = "admin", roles = {"INTERNAL", "ADMIN"})
+  public void testBulkDelete() throws Exception {
+    List<Long> ids = new ArrayList<Long>(Arrays.asList(2L));
+
+
+    // check that the api key we want to delete exists
+    assertNotNull(currentSession().get(ApiKey.class, 2));
+
+    getMockMvc()
+        .perform(post(CONTROLLER_BASE + "/bulk-delete").contentType(MediaType.APPLICATION_JSON)
+            .content(makeJson(ids)))
+        .andExpect(status().isNoContent());
+
+    // now check that the api key was actually deleted
+    assertNull(currentSession().get(ApiKey.class, 2));
+  }
+
+  @Test
+  public void testDeleteFail() throws Exception {
+    List<Long> ids = new ArrayList<Long>(Arrays.asList(2L));
+
+
+    // check that the api key we want to delete exists
+    assertNotNull(currentSession().get(ApiKey.class, 2));
+
+    getMockMvc()
+        .perform(post(CONTROLLER_BASE + "/bulk-delete").contentType(MediaType.APPLICATION_JSON)
+            .content(makeJson(ids)))
+        .andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4431

Note that a mock api key was added to the integration test data script as there was not one there prior, and attempting to create an API key in the test method to put into the database proved to be quite difficult.