### PR TITLE
[GLT-4645] added Spring Test controller endpoint coverage metrics

### DIFF
--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -288,11 +288,6 @@
       <version>3.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>jacoco-maven-plugin</artifactId>
-      <version>0.8.12</version>
-    </dependency>
   </dependencies>
   <build>
     <finalName>ROOT</finalName>
@@ -1075,7 +1070,6 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.12</version>
               <executions>        
                 <execution>
                   <id>prepare-agent-integration</id>

--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <skipITs>true</skipITs>
     <skipSTs>true</skipSTs>
+    <jacoco.skip>true</jacoco.skip>
     <cargoInitGoal>start</cargoInitGoal>
     <mysql.db>lims</mysql.db>
     <mysql.rootpw>abc123</mysql.rootpw>
@@ -286,6 +287,11 @@
       <artifactId>hamcrest</artifactId>
       <version>3.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>0.8.12</version>
     </dependency>
   </dependencies>
   <build>
@@ -1067,6 +1073,40 @@
             </configuration>
           </plugin>
           <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.12</version>
+              <executions>        
+                <execution>
+                  <id>prepare-agent-integration</id>
+                  <goals>
+                    <goal>prepare-agent-integration</goal>
+                  </goals>
+                    <phase>pre-integration-test</phase>
+                    <configuration>
+                      <propertyName>jacoco.failsafe.argLine</propertyName>
+                    </configuration>
+                </execution>
+                <execution>
+                  <id>report-integration</id>
+                  <phase>post-integration-test</phase>
+                  <goals>
+                    <goal>report-integration</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <includes>
+                  <include>**/webapp/controller/rest/*Controller*</include>
+                  <include>**/webapp/controller/view/*Controller*</include>
+                </includes>
+                <excludes>
+                  <exclude>**/webapp/controller/view/Abstract*</exclude>
+                </excludes>
+              <formats>HTML</formats>
+              </configuration>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <executions>
@@ -1086,6 +1126,7 @@
                 <miso.it.mysql.pw>${mysql.pw}</miso.it.mysql.pw>
                 <security.method>jdbc</security.method>
               </systemPropertyVariables>
+              <argLine>${jacoco.failsafe.argLine}</argLine>
               <skipITs>${skipSTs}</skipITs>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>              
               <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -667,6 +667,11 @@
           <artifactId>resources-optimizer-maven-plugin</artifactId>
           <version>2.6.1</version>
         </plugin>
+        <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.12</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4645

Now, when you run `mvn clean verify -DskipSTs=false ...`, an `index.html` file will be created in `/miso-web/target/site/`. Opening this file in a browser will take you to a report which gives you information regarding the endpoint coverage.