### PR TITLE
[GLT-4655] pool rest test fix due to change in test data from a different test

### DIFF
--- a/miso-web/src/spring-test/java/uk/ac/bbsrc/tgac/miso/webapp/springtest/PoolRestControllerST.java
+++ b/miso-web/src/spring-test/java/uk/ac/bbsrc/tgac/miso/webapp/springtest/PoolRestControllerST.java
@@ -68,7 +68,7 @@ public class PoolRestControllerST extends AbstractST {
     getMockMvc().perform(get(CONTROLLER_BASE + "/1/runs"))
         .andExpect(jsonPath("$.*", hasSize(1)))
         .andExpect(jsonPath("$[0].id").value(1))
-        .andExpect(jsonPath("$[0].instrumentId").value(2))
+        .andExpect(jsonPath("$[0].instrumentId").value(1))
         .andExpect(jsonPath("$[0].name").value("RUN1"))
         .andExpect(jsonPath("$[0].type").value("Illumina"));
   }
@@ -392,7 +392,7 @@ public class PoolRestControllerST extends AbstractST {
         .andExpect(jsonPath("$.*", hasSize(1)))
         .andExpect(jsonPath("$[0].id").value(1))
         .andExpect(jsonPath("$[0].name").value("RUN1"))
-        .andExpect(jsonPath("$[0].instrumentId").value(2));
+        .andExpect(jsonPath("$[0].instrumentId").value(1));
   }
 
   @Test


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4655

My apologies, I changed the test data in a different controller test so Run with id 1 now uses instrument with id 1 instead of id 2. I didn't realize this before I merged the pool rest tests, so this is a fix for that.