### PR TITLE
[GLT-4755] prevent transferring identity and ghost samples

### DIFF
--- a/changes/change_transferSamples.md
+++ b/changes/change_transferSamples.md
@@ -1,0 +1,1 @@
+Identity and ghost/synthetic samples can no longer be added to transfers (detailed sample)

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -846,14 +846,14 @@ public class DefaultSampleService implements SampleService {
     validateDetailedQcStatus(sample, errors);
 
     if (isDetailedSample(sample)) {
-      DetailedSample detailed = (DetailedSample) sample;
+      DetailedSample detailed = (DetailedSample) deproxify(sample);
       validateSubproject(detailed, beforeChange, errors);
       validateReferenceSlide(detailed, errors);
       validateGroupDescription(detailed, errors);
-      if (isIdentitySample(sample) && sample.getRequisition() != null) {
+      if (isIdentitySample(detailed) && detailed.getRequisition() != null) {
         errors.add(new ValidationError("requisitionId", "Identity samples cannot be added to requisitions"));
-      } else if (isProcessingSingleCellSample(sample)) {
-        SampleSingleCell singleCell = (SampleSingleCell) sample;
+      } else if (isProcessingSingleCellSample(detailed)) {
+        SampleSingleCell singleCell = (SampleSingleCell) detailed;
         if (singleCell.getProbes() != null && !singleCell.getProbes().isEmpty()) {
           validateProbes(singleCell.getProbes(), errors);
         }
@@ -872,8 +872,9 @@ public class DefaultSampleService implements SampleService {
       }
     }
 
-    if (sample.getCreationReceiptInfo() != null) {
-      validateReceiptTransfer(sample.getCreationReceiptInfo(), errors);
+    TransferSample receiptSample = sample.getCreationReceiptInfo();
+    if (receiptSample != null) {
+      validateReceiptTransfer(receiptSample, errors);
     }
 
     if (!errors.isEmpty()) {
@@ -906,12 +907,12 @@ public class DefaultSampleService implements SampleService {
     if (isTissuePieceSample(sample)) {
       referenceId = ((SampleTissuePiece) sample).getReferenceSlideId();
     } else if (isStockSample(sample)) {
-      referenceId = ((SampleStock) deproxify(sample)).getReferenceSlideId();
+      referenceId = ((SampleStock) sample).getReferenceSlideId();
     } else {
       return;
     }
     if (referenceId != null) {
-      DetailedSample reference = (DetailedSample) deproxify(get(referenceId));
+      DetailedSample reference = (DetailedSample) get(referenceId);
       if (reference == null) {
         errors.add(new ValidationError("referenceSlideId", "Reference slide not found"));
         return;

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTransferService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTransferService.java
@@ -1,5 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.service.impl;
 
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.*;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -21,6 +23,7 @@ import com.eaglegenomics.simlims.core.User;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractBoxPosition;
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
+import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Lab;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
@@ -240,6 +243,20 @@ public class DefaultTransferService extends AbstractSaveService<Transfer> implem
       }
       if (!transfer.getPoolTransfers().isEmpty()) {
         errors.add(new ValidationError("items", "Pools cannot be received directly"));
+      }
+    }
+
+    for (TransferSample transferSample : transfer.getSampleTransfers()) {
+      if (!isDetailedSample(transferSample.getItem())) {
+        break;
+      }
+      DetailedSample sample = (DetailedSample) deproxify(transferSample.getItem());
+      if (isIdentitySample(sample)) {
+        errors.add(new ValidationError("items", "%s (%s) cannot be transferred because it is an identity sample"
+            .formatted(sample.getAlias(), sample.getName())));
+      } else if (sample.isSynthetic()) {
+        errors.add(new ValidationError("items", "%s (%s) cannot be transferred because it is a ghost/synthetic sample"
+            .formatted(sample.getAlias(), sample.getName())));
       }
     }
 


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4755

- [x] Includes a change file

The validation is a better solution that avoids the ClassCastException bug, but I fixed the bug as well (deproxying before any casting) since it could affect other things.