### PR TITLE
Bump pinery version to 3.4.0

### DIFF
--- a/pinery-miso/pom.xml
+++ b/pinery-miso/pom.xml
@@ -20,7 +20,7 @@
     <mysql.pw>tgaclims</mysql.pw>
     <db.params>
       autoReconnect=true&amp;characterEncoding=UTF-8&amp;allowPublicKeyRetrieval=true&amp;sslMode=DISABLED&amp;connectionTimeZone=SERVER&amp;cacheDefaultTimeZone=false</db.params>
-    <pinery.version>3.3.0</pinery.version>
+    <pinery.version>3.4.0</pinery.version>
     <spring.version>6.1.13</spring.version><!-- must match version used by Pinery -->
   </properties>
 


### PR DESCRIPTION
Dillan requested a pinery and MISO release. Prepared the 3.4.0 pinery release for tomorrow's MISO stage deploy. This PR updates MISO to use the newest version of pinery.

Does this need to be merged right before the stage MISO release is done or can it be merged ahead of time (today, for example)?

Jira ticket or GitHub issue:

- [ ] Includes a change file
