### PR TITLE
#3221: add configuration to hide bulk table columns

### DIFF
--- a/changes/add_bulk_column_visibility_config.md
+++ b/changes/add_bulk_column_visibility_config.md
@@ -1,0 +1,9 @@
+Configuration options to hide columns on bulk edit/create pages. The following `miso.properties`
+settings can be set to `false` to hide their respective column groups (all default to `true`):
+* `miso.display.bulk.receiptQc` - Receipt Confirmed, Receipt QC Passed, Receipt QC Note
+* `miso.display.bulk.requisition` - Requisition Alias, Requisition, Assay
+* `miso.display.bulk.qcStatus` - QC Status, QC Note
+* `miso.display.bulk.matrixBarcode` - Matrix Barcode
+* `miso.display.bulk.discarded` - Discarded
+* `miso.display.bulk.defaultDetailedQcStatus` - when `qcStatus` is hidden, sets the default QC
+  status value (should match a configured QC status description)

--- a/docs/admin/site-configuration.md
+++ b/docs/admin/site-configuration.md
@@ -365,6 +365,38 @@ Defaults to `true` if unspecified. Set to `false` to hide the description column
 
 Defaults to `true` if unspecified. Set to `false` to hide the volume column when bulk creating/editing libraries.
 
+### `miso.display.bulk.receiptQc`
+
+Defaults to `true` if unspecified. Set to `false` to hide the Receipt Confirmed, Receipt QC Passed,
+and Receipt QC Note columns on bulk create/edit pages.
+
+### `miso.display.bulk.requisition`
+
+Defaults to `true` if unspecified. Set to `false` to hide the Requisition Alias, Requisition, and
+Assay columns on bulk create/edit pages.
+
+### `miso.display.bulk.qcStatus`
+
+Defaults to `true` if unspecified. Set to `false` to hide the QC Status and QC Note columns on bulk
+create/edit pages. If hidden, consider also setting `miso.defaults.bulk.detailedQcStatus`.
+
+### `miso.display.bulk.matrixBarcode`
+
+Defaults to `true` if unspecified. Set to `false` to hide the Matrix Barcode column on bulk
+create/edit pages.
+
+### `miso.display.bulk.discarded`
+
+Defaults to `true` if unspecified. Set to `false` to hide the Discarded column on bulk create/edit
+pages.
+
+### `miso.defaults.bulk.detailedQcStatus`
+
+Default QC status to apply on bulk create/edit pages. Set to the description of a QC status (e.g.
+"Ready"). When the QC Status column is visible, this pre-selects the value but the user can change
+it. When the QC Status column is hidden via `miso.display.bulk.qcStatus`, this value is applied
+automatically on save.
+
 ## Index Checking
 
 ### `miso.pools.strictIndexChecking`

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
@@ -240,6 +240,19 @@ public class ConstantsController {
   @Value("${miso.newOptionSopUrl:#{null}}")
   private String newOptionSopUrl;
 
+  @Value("${miso.display.bulk.receiptQc:true}")
+  private boolean showReceiptQc;
+  @Value("${miso.display.bulk.requisition:true}")
+  private boolean showRequisition;
+  @Value("${miso.display.bulk.qcStatus:true}")
+  private boolean showQcStatus;
+  @Value("${miso.display.bulk.matrixBarcode:true}")
+  private boolean showMatrixBarcode;
+  @Value("${miso.display.bulk.discarded:true}")
+  private boolean showDiscarded;
+  @Value("${miso.display.bulk.defaultDetailedQcStatus:#{null}}")
+  private String defaultDetailedQcStatus;
+
   @Resource
   private Boolean boxScannerEnabled;
 
@@ -279,6 +292,12 @@ public class ConstantsController {
       node.put("automaticBarcodes", autoGenerateIdBarcodes);
       node.put("boxScannerEnabled", boxScannerEnabled);
       node.put("newOptionSopUrl", newOptionSopUrl);
+      node.put("showReceiptQc", showReceiptQc);
+      node.put("showRequisition", showRequisition);
+      node.put("showQcStatus", showQcStatus);
+      node.put("showMatrixBarcode", showMatrixBarcode);
+      node.put("showDiscarded", showDiscarded);
+      node.put("defaultDetailedQcStatus", defaultDetailedQcStatus);
 
       final Collection<SampleValidRelationship> relationships = sampleValidRelationshipService.getAll();
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
@@ -250,7 +250,7 @@ public class ConstantsController {
   private boolean showMatrixBarcode;
   @Value("${miso.display.bulk.discarded:true}")
   private boolean showDiscarded;
-  @Value("${miso.display.bulk.defaultDetailedQcStatus:#{null}}")
+  @Value("${miso.defaults.bulk.detailedQcStatus:#{null}}")
   private String defaultDetailedQcStatus;
 
   @Resource

--- a/miso-web/src/main/resources/miso.properties
+++ b/miso-web/src/main/resources/miso.properties
@@ -90,6 +90,14 @@ miso.display.library.bulk.libraryalias:true
 miso.display.library.bulk.description:false
 miso.display.library.bulk.volume:false
 
+## bulk table column visibility settings (all default to true/visible)
+# miso.display.bulk.receiptQc:true
+# miso.display.bulk.requisition:true
+# miso.display.bulk.qcStatus:true
+# miso.display.bulk.matrixBarcode:true
+# miso.display.bulk.discarded:true
+# miso.display.bulk.defaultDetailedQcStatus:
+
 ## Strict Index Conflict rules for adding Library Aliquots to Pools.
 ## When enabled, Library Aliquots with duplicate or near-duplicate indices cannot be added to Pools.
 miso.pools.strictIndexChecking:false

--- a/miso-web/src/main/resources/miso.properties
+++ b/miso-web/src/main/resources/miso.properties
@@ -96,7 +96,7 @@ miso.display.library.bulk.volume:false
 # miso.display.bulk.qcStatus:true
 # miso.display.bulk.matrixBarcode:true
 # miso.display.bulk.discarded:true
-# miso.display.bulk.defaultDetailedQcStatus:
+# miso.defaults.bulk.detailedQcStatus:
 
 ## Strict Index Conflict rules for adding Library Aliquots to Pools.
 ## When enabled, Library Aliquots with duplicate or near-duplicate indices cannot be added to Pools.

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -258,6 +258,26 @@ BulkUtils = (function ($) {
       });
     },
 
+    applyDefaultDetailedQcStatus: function (data) {
+      if (Constants.showQcStatus !== false || !Constants.defaultDetailedQcStatus) {
+        return;
+      }
+      var status = Constants.detailedQcStatuses.find(function (s) {
+        return s.description === Constants.defaultDetailedQcStatus;
+      });
+      if (!status) {
+        return;
+      }
+      data.forEach(function (item) {
+        if (!item.detailedQcStatusId) {
+          item.detailedQcStatusId = status.id;
+        }
+        if (item.sample && !item.sample.detailedQcStatusId) {
+          item.sample.detailedQcStatusId = status.id;
+        }
+      });
+    },
+
     columns: {
       name: {
         title: "Name",
@@ -799,7 +819,7 @@ BulkUtils = (function ($) {
               ).description;
             },
             required: true,
-            initial: Constants.showQcStatus === false ? Constants.defaultDetailedQcStatus : undefined,
+            initial: Constants.defaultDetailedQcStatus || undefined,
             source: function (data, api) {
               return [
                 {
@@ -2412,7 +2432,9 @@ BulkUtils = (function ($) {
   }
 
   function isColumnHidden(dataProperty) {
-    switch (dataProperty) {
+    // Strip "sample." prefix for library receipt page where sample columns are nested
+    var prop = dataProperty.replace(/^sample\./, "");
+    switch (prop) {
       case "received":
       case "receiptQcPassed":
       case "receiptQcNote":

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -384,6 +384,7 @@ BulkUtils = (function ($) {
             title: "Receipt Confirmed",
             type: "dropdown",
             data: "received",
+            include: Constants.showReceiptQc !== false,
             includeSaved: false,
             source: [
               {
@@ -411,6 +412,7 @@ BulkUtils = (function ($) {
             title: "Receipt QC Passed",
             type: "dropdown",
             data: "receiptQcPassed",
+            include: Constants.showReceiptQc !== false,
             includeSaved: false,
             source: [
               {
@@ -443,6 +445,7 @@ BulkUtils = (function ($) {
             title: "Receipt QC Note",
             type: "text",
             data: "receiptQcNote",
+            include: Constants.showReceiptQc !== false,
             includeSaved: false,
           },
         ];
@@ -459,7 +462,7 @@ BulkUtils = (function ($) {
         title: "Matrix Barcode",
         type: "text",
         data: "identificationBarcode",
-        include: !Constants.automaticBarcodes,
+        include: !Constants.automaticBarcodes && Constants.showMatrixBarcode !== false,
         maxLength: 255,
       },
 
@@ -601,6 +604,7 @@ BulkUtils = (function ($) {
             title: "Discarded",
             type: "dropdown",
             data: "discarded",
+            include: Constants.showDiscarded !== false,
             required: true,
             source: [
               {
@@ -782,6 +786,7 @@ BulkUtils = (function ($) {
             title: "QC Status",
             type: "dropdown",
             data: "detailedQcStatusId",
+            include: Constants.showQcStatus !== false,
             getData: function (object, limitedApi) {
               if (!object.detailedQcStatusId) {
                 return pageMode === "edit" ? "Not Ready" : null;
@@ -794,6 +799,7 @@ BulkUtils = (function ($) {
               ).description;
             },
             required: true,
+            initial: Constants.showQcStatus === false ? Constants.defaultDetailedQcStatus : undefined,
             source: function (data, api) {
               return [
                 {
@@ -830,6 +836,7 @@ BulkUtils = (function ($) {
             title: "QC Note",
             type: "text",
             data: "detailedQcStatusNote",
+            include: Constants.showQcStatus !== false,
           },
         ];
       },
@@ -890,6 +897,7 @@ BulkUtils = (function ($) {
             title: "Requisition Alias",
             data: "requisitionAlias",
             type: "text",
+            include: Constants.showRequisition !== false,
             maxLength: 150,
             description:
               "Should usually match the ID of a requisition form stored in a separate system. Enter an alias to " +
@@ -952,6 +960,7 @@ BulkUtils = (function ($) {
             title: "Requisition",
             type: "dropdown",
             data: "requisitionId",
+            include: Constants.showRequisition !== false,
             includeSaved: false,
             getItemLabel: Utils.array.getAlias,
             getItemValue: Utils.array.getId,
@@ -1009,6 +1018,7 @@ BulkUtils = (function ($) {
         return {
           title: "Assay",
           data: "requisitionAssayIds",
+          include: Constants.showRequisition !== false,
           getData: function (object, limitedApi) {
             if (!object.requisitionAssayIds || !object.requisitionAssayIds.length) {
               return null;
@@ -1964,7 +1974,8 @@ BulkUtils = (function ($) {
       var storingChanges = true;
       onChangeApi.updateField = function (rowIndex, dataProperty, changes) {
         if (storingChanges && changes.hasOwnProperty("value") && changes.value !== undefined) {
-          var colIndex = getColumnIndex(dataProperty, columns);
+          var colIndex = getColumnIndex(dataProperty, columns, true);
+          if (colIndex === null) return; // column hidden by config
           dataChanges.push([rowIndex, colIndex, changes.value]);
           // clone object before modification in-case same is being used for multiple fields
           changes = Object.assign({}, changes);
@@ -2429,7 +2440,8 @@ BulkUtils = (function ($) {
 
     api.getValueObject = function (row, dataProperty) {
       // Note: currently only works for columns where the source is set individually per row
-      var colIndex = getColumnIndex(dataProperty, columns);
+      var colIndex = getColumnIndex(dataProperty, columns, true);
+      if (colIndex === null) return null; // column hidden by config
       var column = columns[colIndex];
       if (column.type !== "dropdown") {
         throw new Error("Cannot get value object for non-dropdown column: " + dataProperty);
@@ -2440,7 +2452,8 @@ BulkUtils = (function ($) {
     };
 
     api.getSourceData = function (row, dataProperty) {
-      var colIndex = getColumnIndex(dataProperty, columns);
+      var colIndex = getColumnIndex(dataProperty, columns, true);
+      if (colIndex === null) return null; // column hidden by config
       return hot.getCellMeta(row, colIndex).sourceData;
     };
 
@@ -2469,7 +2482,8 @@ BulkUtils = (function ($) {
   }
 
   function updateField(hot, columns, rowIndex, dataProperty, options) {
-    var colIndex = getColumnIndex(dataProperty, columns);
+    var colIndex = getColumnIndex(dataProperty, columns, true);
+    if (colIndex === null) return; // column hidden by config
     var column = columns[colIndex];
     var forceValidate = false;
 
@@ -2593,7 +2607,8 @@ BulkUtils = (function ($) {
 
       getValueObject: function (row, dataProperty) {
         // Note: currently only works for columns where the source is set individually per row
-        var colIndex = getColumnIndex(dataProperty, columns);
+        var colIndex = getColumnIndex(dataProperty, columns, true);
+        if (colIndex === null) return null; // column hidden by config
         var column = columns[colIndex];
         if (column.type !== "dropdown") {
           throw new Error("Cannot get value object for non-dropdown column: " + dataProperty);
@@ -2607,7 +2622,8 @@ BulkUtils = (function ($) {
       },
 
       getSourceData: function (rowIndex, dataProperty) {
-        var colIndex = getColumnIndex(dataProperty, columns);
+        var colIndex = getColumnIndex(dataProperty, columns, true);
+        if (colIndex === null) return null; // column hidden by config
         var cellMeta = cellMetas.find(function (meta) {
           return meta.row === rowIndex && meta.col === colIndex;
         });
@@ -2615,9 +2631,9 @@ BulkUtils = (function ($) {
       },
 
       updateField: function (rowIndex, dataProperty, options) {
-        var colIndex = getColumnIndex(dataProperty, columns, tableSaved);
+        var colIndex = getColumnIndex(dataProperty, columns, true);
         if (colIndex === null) {
-          // Column not shown after save - ignore updates
+          // Column hidden by config or not shown after save - ignore updates
           return;
         }
         var column = columns[colIndex];

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -258,7 +258,10 @@ BulkUtils = (function ($) {
       });
     },
 
-    applyDefaultDetailedQcStatus: function (data) {
+    applyDefaultDetailedQcStatus: function (data, config) {
+      if (config && config.pageMode === "edit") {
+        return;
+      }
       if (Constants.showQcStatus !== false || !Constants.defaultDetailedQcStatus) {
         return;
       }

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -1974,7 +1974,7 @@ BulkUtils = (function ($) {
       var storingChanges = true;
       onChangeApi.updateField = function (rowIndex, dataProperty, changes) {
         if (storingChanges && changes.hasOwnProperty("value") && changes.value !== undefined) {
-          var colIndex = getColumnIndex(dataProperty, columns, true);
+          var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
           if (colIndex === null) return; // column hidden by config
           dataChanges.push([rowIndex, colIndex, changes.value]);
           // clone object before modification in-case same is being used for multiple fields
@@ -2411,6 +2411,28 @@ BulkUtils = (function ($) {
     return incrementedString;
   }
 
+  function isColumnHidden(dataProperty) {
+    switch (dataProperty) {
+      case "received":
+      case "receiptQcPassed":
+      case "receiptQcNote":
+        return Constants.showReceiptQc === false;
+      case "requisitionAlias":
+      case "requisitionId":
+      case "requisitionAssayIds":
+        return Constants.showRequisition === false;
+      case "detailedQcStatusId":
+      case "detailedQcStatusNote":
+        return Constants.showQcStatus === false;
+      case "identificationBarcode":
+        return Constants.showMatrixBarcode === false;
+      case "discarded":
+        return Constants.showDiscarded === false;
+      default:
+        return false;
+    }
+  }
+
   function getColumnIndex(dataProperty, columns, nullOk) {
     var colIndex = columns.findIndex(function (column) {
       return column.data === dataProperty;
@@ -2440,7 +2462,7 @@ BulkUtils = (function ($) {
 
     api.getValueObject = function (row, dataProperty) {
       // Note: currently only works for columns where the source is set individually per row
-      var colIndex = getColumnIndex(dataProperty, columns, true);
+      var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
       if (colIndex === null) return null; // column hidden by config
       var column = columns[colIndex];
       if (column.type !== "dropdown") {
@@ -2452,7 +2474,7 @@ BulkUtils = (function ($) {
     };
 
     api.getSourceData = function (row, dataProperty) {
-      var colIndex = getColumnIndex(dataProperty, columns, true);
+      var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
       if (colIndex === null) return null; // column hidden by config
       return hot.getCellMeta(row, colIndex).sourceData;
     };
@@ -2482,7 +2504,7 @@ BulkUtils = (function ($) {
   }
 
   function updateField(hot, columns, rowIndex, dataProperty, options) {
-    var colIndex = getColumnIndex(dataProperty, columns, true);
+    var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
     if (colIndex === null) return; // column hidden by config
     var column = columns[colIndex];
     var forceValidate = false;
@@ -2607,7 +2629,7 @@ BulkUtils = (function ($) {
 
       getValueObject: function (row, dataProperty) {
         // Note: currently only works for columns where the source is set individually per row
-        var colIndex = getColumnIndex(dataProperty, columns, true);
+        var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
         if (colIndex === null) return null; // column hidden by config
         var column = columns[colIndex];
         if (column.type !== "dropdown") {
@@ -2622,7 +2644,7 @@ BulkUtils = (function ($) {
       },
 
       getSourceData: function (rowIndex, dataProperty) {
-        var colIndex = getColumnIndex(dataProperty, columns, true);
+        var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
         if (colIndex === null) return null; // column hidden by config
         var cellMeta = cellMetas.find(function (meta) {
           return meta.row === rowIndex && meta.col === colIndex;
@@ -2631,7 +2653,7 @@ BulkUtils = (function ($) {
       },
 
       updateField: function (rowIndex, dataProperty, options) {
-        var colIndex = getColumnIndex(dataProperty, columns, true);
+        var colIndex = getColumnIndex(dataProperty, columns, tableSaved || isColumnHidden(dataProperty));
         if (colIndex === null) {
           // Column hidden by config or not shown after save - ignore updates
           return;

--- a/miso-web/src/main/webapp/scripts/bulk_library.js
+++ b/miso-web/src/main/webapp/scripts/bulk_library.js
@@ -973,7 +973,7 @@ BulkTarget.library = (function ($) {
 
     confirmSave: function (data, config) {
       var deferred = $.Deferred();
-      BulkUtils.applyDefaultDetailedQcStatus(data);
+      BulkUtils.applyDefaultDetailedQcStatus(data, config);
       if (config.isLibraryReceipt) {
         BulkUtils.checkPausedRequisitions(data, deferred);
       } else {

--- a/miso-web/src/main/webapp/scripts/bulk_library.js
+++ b/miso-web/src/main/webapp/scripts/bulk_library.js
@@ -973,6 +973,7 @@ BulkTarget.library = (function ($) {
 
     confirmSave: function (data, config) {
       var deferred = $.Deferred();
+      BulkUtils.applyDefaultDetailedQcStatus(data);
       if (config.isLibraryReceipt) {
         BulkUtils.checkPausedRequisitions(data, deferred);
       } else {

--- a/miso-web/src/main/webapp/scripts/bulk_libraryaliquot.js
+++ b/miso-web/src/main/webapp/scripts/bulk_libraryaliquot.js
@@ -457,9 +457,9 @@ BulkTarget.libraryaliquot = (function ($) {
         }
       });
     },
-    confirmSave: function (data) {
+    confirmSave: function (data, config) {
       var deferred = jQuery.Deferred();
-      BulkUtils.applyDefaultDetailedQcStatus(data);
+      BulkUtils.applyDefaultDetailedQcStatus(data, config);
 
       var overused = data.filter(function (aliquot, index) {
         return (

--- a/miso-web/src/main/webapp/scripts/bulk_libraryaliquot.js
+++ b/miso-web/src/main/webapp/scripts/bulk_libraryaliquot.js
@@ -459,6 +459,7 @@ BulkTarget.libraryaliquot = (function ($) {
     },
     confirmSave: function (data) {
       var deferred = jQuery.Deferred();
+      BulkUtils.applyDefaultDetailedQcStatus(data);
 
       var overused = data.filter(function (aliquot, index) {
         return (

--- a/miso-web/src/main/webapp/scripts/bulk_sample.js
+++ b/miso-web/src/main/webapp/scripts/bulk_sample.js
@@ -1431,7 +1431,7 @@ BulkTarget.sample = (function ($) {
 
     confirmSave: function (data, config) {
       var deferred = $.Deferred();
-      BulkUtils.applyDefaultDetailedQcStatus(data);
+      BulkUtils.applyDefaultDetailedQcStatus(data, config);
       if (Constants.isDetailedSample) {
         data.forEach(function (sample) {
           var sampleClass = Utils.array.findUniqueOrThrow(

--- a/miso-web/src/main/webapp/scripts/bulk_sample.js
+++ b/miso-web/src/main/webapp/scripts/bulk_sample.js
@@ -1431,6 +1431,7 @@ BulkTarget.sample = (function ($) {
 
     confirmSave: function (data, config) {
       var deferred = $.Deferred();
+      BulkUtils.applyDefaultDetailedQcStatus(data);
       if (Constants.isDetailedSample) {
         data.forEach(function (sample) {
           var sampleClass = Utils.array.findUniqueOrThrow(


### PR DESCRIPTION
Closes https://github.com/miso-lims/miso-lims/issues/3221                                                                                
                                              
  ## Summary

  Adds `miso.properties` flags to control visibility of column groups on bulk edit/create pages:                                           
  - `miso.display.bulk.receiptQc` — Receipt Confirmed, Receipt QC Passed, Receipt QC Note
  - `miso.display.bulk.requisition` — Requisition Alias, Requisition, Assay                                                                
  - `miso.display.bulk.qcStatus` — QC Status, QC Note                                                                                      
  - `miso.display.bulk.matrixBarcode` — Matrix Barcode
  - `miso.display.bulk.discarded` — Discarded                                                                                              
  - `miso.display.bulk.defaultDetailedQcStatus` — configurable default QC status when qcStatus is hidden
                                                                                                                                           
  All flags default to `true` (visible), so existing installations are unaffected.
                                                                                                                                           
  ## Technical notes                          

  All `getColumnIndex` call sites made null-tolerant so that cross-column `onChange` handlers (e.g., Date of Receipt → Receipt Confirmed)  
  gracefully skip hidden columns instead of throwing errors.