### PR TITLE
[GLT-4780] fixed ClassCastException when saving samples

### DIFF
--- a/changes/fix_transferSample.md
+++ b/changes/fix_transferSample.md
@@ -1,0 +1,1 @@
+Unexpected error when attempting to add some samples to distribution transfers

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -852,11 +852,11 @@ public class DefaultSampleService implements SampleService {
       validateGroupDescription(detailed, errors);
       if (isIdentitySample(detailed) && detailed.getRequisition() != null) {
         errors.add(new ValidationError("requisitionId", "Identity samples cannot be added to requisitions"));
-      } else if (isTissueSample(sample)) {
-        SampleTissue tissue = (SampleTissue) sample;
+      } else if (isTissueSample(detailed)) {
+        SampleTissue tissue = (SampleTissue) detailed;
         validateUriComponent("timepoint", tissue.getTimepoint(), errors);
-      } else if (isProcessingSingleCellSample(sample)) {
-        SampleSingleCell singleCell = (SampleSingleCell) sample;
+      } else if (isProcessingSingleCellSample(detailed)) {
+        SampleSingleCell singleCell = (SampleSingleCell) detailed;
         if (singleCell.getProbes() != null && !singleCell.getProbes().isEmpty()) {
           validateProbes(singleCell.getProbes(), errors);
         }


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4780

- [x] Includes a change file

The change here is to use the "deproxified" object when casting. Some samples work and some don't currently. I'm guessing that Hibernate is proxying samples with some lazy-loaded collection and not proxying others where that collection is empty or null.