### PR TITLE
[GLT-4783] fixed filename parsing in ajaxDownloadWithDialog

### DIFF
--- a/changes/fix_download_filenames.md
+++ b/changes/fix_download_filenames.md
@@ -1,0 +1,1 @@
+Strange filenames for samplesheets and possibly other file downloads

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -706,7 +706,23 @@ var Utils = Utils || {
       if (request.readyState === 4) {
         dialog.dialog("close");
         if (request.status === 200) {
-          var filename = /filename=(.*)$/.exec(request.getResponseHeader("Content-Disposition"))[1];
+          contentDisposition = request.getResponseHeader("Content-Disposition");
+          var filename = null;
+          var match = /filename\*=(?:UTF-8'')?(.*)(?:; ?|$)/.exec(
+            request.getResponseHeader("Content-Disposition")
+          );
+          if (match) {
+            filename = decodeURIComponent(match[1]);
+          } else {
+            match = filename = /filename=(["']?)(.*)\1(?:; ?|$)/.exec(
+              request.getResponseHeader("Content-Disposition")
+            );
+            if (match) {
+              filename = match[2];
+            } else {
+              throw Error("Couldn't determine filename for download");
+            }
+          }
           download(request.response, filename, request.getResponseHeader("Content-Type"));
         } else {
           Utils.showOkDialog("Error", ["Download failed."]);


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4783

- [x] Includes a change file
