### PR TITLE
#3232 Queued identityId renders to increase performance on bulk sample import

### DIFF
--- a/changes/fix_bulk_create_samples_performance.md
+++ b/changes/fix_bulk_create_samples_performance.md
@@ -1,0 +1,1 @@
+Improved performance when creating samples in bulk.

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -115,13 +115,14 @@ BulkUtils = (function ($) {
    *   getValueObject: function(row, dataProperty): get the object represented by the current cell
    *       value (for dropdown columns)
    *   getSourceData: function(rowIndex, dataProperty); get the backing data for a dropdown field
-   *   updateField: function(rowIndex, dataProperty, options). options may include
+   *   updateField: function(rowIndex, dataProperty, options, bulkRender). options may include
    *       * 'value' (string)
    *       * 'source' (array of objects)
    *       * 'required' (boolean)
    *       * 'disabled' (boolean)
    *       * 'formatter' (string)
    *       * 'type' (string; only 'decimal' and 'dropdown' supported)
+   *       bulkRender=true reduces render calls when updateData cannot be used.
    *   updateData: function(changes); update fields in bulk. Use this rather than multiple
    *       updateField calls to improve performance. changes is an array of arrays where the inner
    *       arrays have three elements - rowIndex, dataProperty, and newValue

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -2524,14 +2524,6 @@ BulkUtils = (function ($) {
       updateField(hot, columns, rowIndex, dataProperty, options, bulkRender);
     };
 
-    api.renderFields = function (changes) {
-      hot.setDataAtCell(
-          changes.map(function (change) {
-            return [change[0], getColumnIndex(change[1], columns), change[2]];
-          })
-      );
-    };
-
     api.updateData = function (changes) {
       // changes = [[row, prop, value]...]
       hot.setDataAtRowProp(changes);

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -186,6 +186,17 @@ BulkUtils = (function ($) {
     },
   };
 
+    var bulkRenderQueue = [];
+    var bulkRenderTimer = null;
+
+    function setBulkRenderTimer(hot) {
+      clearTimeout(bulkRenderTimer);
+      bulkRenderTimer = setTimeout(function () {
+        var changes = bulkRenderQueue.splice(0);
+        hot.setDataAtCell(changes);
+      }, 50);
+    }
+
   return {
     makeTable: function (target, config, data) {
       // No HTML IDs params required as this is only made to work with bulkPage.jsp
@@ -2000,7 +2011,7 @@ BulkUtils = (function ($) {
       extendApi(onChangeApi, hot, columns, config, data);
       var dataChanges = [];
       var storingChanges = true;
-      onChangeApi.updateField = function (rowIndex, dataProperty, changes, skipRender) {
+      onChangeApi.updateField = function (rowIndex, dataProperty, changes, bulkRender) {
         if (storingChanges && changes.hasOwnProperty("value") && changes.value !== undefined) {
           var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
           if (colIndex === null) return; // column hidden by config
@@ -2009,7 +2020,7 @@ BulkUtils = (function ($) {
           changes = Object.assign({}, changes);
           changes.value = undefined;
         }
-        updateField(hot, columns, rowIndex, dataProperty, changes, skipRender);
+        updateField(hot, columns, rowIndex, dataProperty, changes, bulkRender);
       };
       changes.forEach(function (change) {
         if (listeners[change[1]]) {
@@ -2509,8 +2520,8 @@ BulkUtils = (function ($) {
       return hot.getCellMeta(row, colIndex).sourceData;
     };
 
-    api.updateField = function (rowIndex, dataProperty, options, skipRender) {
-      updateField(hot, columns, rowIndex, dataProperty, options, skipRender);
+    api.updateField = function (rowIndex, dataProperty, options, bulkRender) {
+      updateField(hot, columns, rowIndex, dataProperty, options, bulkRender);
     };
 
     api.renderFields = function (changes) {
@@ -2541,7 +2552,7 @@ BulkUtils = (function ($) {
     };
   }
 
-  function updateField(hot, columns, rowIndex, dataProperty, options, skipRender) {
+  function updateField(hot, columns, rowIndex, dataProperty, options, bulkRender) {
     var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
     if (colIndex === null) return; // column hidden by config
     var column = columns[colIndex];
@@ -2617,8 +2628,13 @@ BulkUtils = (function ($) {
       forceValidate = true;
     }
 
-    if (options.hasOwnProperty("value") && options.value !== undefined && skipRender !== true) {
-      hot.setDataAtCell(rowIndex, colIndex, options.value);
+    if (options.hasOwnProperty("value") && options.value !== undefined) {
+      if (bulkRender === true) {
+        bulkRenderQueue.push([rowIndex, colIndex, options.value]);
+        setBulkRenderTimer(hot);
+      } else {
+        hot.setDataAtCell(rowIndex, colIndex, options.value);
+      }
     } else if (forceValidate) {
       // Note: intended to be a private function, but it works and is more efficient than validating the entire row/column/table
       hot._validateCells(null, [rowIndex], [colIndex]);

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -2000,7 +2000,7 @@ BulkUtils = (function ($) {
       extendApi(onChangeApi, hot, columns, config, data);
       var dataChanges = [];
       var storingChanges = true;
-      onChangeApi.updateField = function (rowIndex, dataProperty, changes) {
+      onChangeApi.updateField = function (rowIndex, dataProperty, changes, skipRender) {
         if (storingChanges && changes.hasOwnProperty("value") && changes.value !== undefined) {
           var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
           if (colIndex === null) return; // column hidden by config
@@ -2009,7 +2009,7 @@ BulkUtils = (function ($) {
           changes = Object.assign({}, changes);
           changes.value = undefined;
         }
-        updateField(hot, columns, rowIndex, dataProperty, changes);
+        updateField(hot, columns, rowIndex, dataProperty, changes, skipRender);
       };
       changes.forEach(function (change) {
         if (listeners[change[1]]) {
@@ -2509,8 +2509,16 @@ BulkUtils = (function ($) {
       return hot.getCellMeta(row, colIndex).sourceData;
     };
 
-    api.updateField = function (rowIndex, dataProperty, options) {
-      updateField(hot, columns, rowIndex, dataProperty, options);
+    api.updateField = function (rowIndex, dataProperty, options, skipRender) {
+      updateField(hot, columns, rowIndex, dataProperty, options, skipRender);
+    };
+
+    api.renderFields = function (changes) {
+      hot.setDataAtCell(
+          changes.map(function (change) {
+            return [change[0], getColumnIndex(change[1], columns), change[2]];
+          })
+      );
     };
 
     api.updateData = function (changes) {
@@ -2533,7 +2541,7 @@ BulkUtils = (function ($) {
     };
   }
 
-  function updateField(hot, columns, rowIndex, dataProperty, options) {
+  function updateField(hot, columns, rowIndex, dataProperty, options, skipRender) {
     var colIndex = getColumnIndex(dataProperty, columns, isColumnHidden(dataProperty));
     if (colIndex === null) return; // column hidden by config
     var column = columns[colIndex];
@@ -2609,7 +2617,7 @@ BulkUtils = (function ($) {
       forceValidate = true;
     }
 
-    if (options.hasOwnProperty("value") && options.value !== undefined) {
+    if (options.hasOwnProperty("value") && options.value !== undefined && skipRender !== true) {
       hot.setDataAtCell(rowIndex, colIndex, options.value);
     } else if (forceValidate) {
       // Note: intended to be a private function, but it works and is more efficient than validating the entire row/column/table

--- a/miso-web/src/main/webapp/scripts/bulk_sample.js
+++ b/miso-web/src/main/webapp/scripts/bulk_sample.js
@@ -16,6 +16,21 @@ BulkTarget.sample = (function ($) {
    * }
    */
 
+  var batchRenderQueue = [];
+  var batchRenderTimer = null;
+
+  function setBatchRenderTimer(api) {
+    clearTimeout(batchRenderTimer);
+    batchRenderTimer = setTimeout(function () {
+      var changes = batchRenderQueue.splice(0);
+      api.renderFields(
+        changes.map(function (change)  {
+          return [change.rowIndex, change.columnName, change.value]
+        })
+      )
+    }, 50);
+  }
+
   // stored state when editing probes
   var probeEditingSamples = null;
   var allSamples = null;
@@ -853,11 +868,25 @@ BulkTarget.sample = (function ($) {
                   });
                   setValue = firstReceiptLabel;
                 }
-                api.updateField(rowIndex, "identityId", {
-                  source: potentialIdentities,
+                var change = {
+                  rowIndex: rowIndex,
+                  columnName: "identityId",
+                  potentialIdentities: potentialIdentities,
                   value: setValue,
-                  formatter: potentialIdentities.length > 1 ? "multipleOptions" : null,
-                });
+                  formatter: potentialIdentities.length > 1 ? "multipleOptions" : null
+                }
+                api.updateField(
+                    change.rowIndex,
+                    change.columnName,
+                    {
+                      source: change.potentialIdentities,
+                      value: change.value,
+                      formatter: change.formatter,
+                    },
+                    true);
+
+                batchRenderQueue.push(change);
+                setBatchRenderTimer(api);
               })
               .fail(function (response, textStatus, serverStatus) {
                 var error = JSON.parse(response.responseText);

--- a/miso-web/src/main/webapp/scripts/bulk_sample.js
+++ b/miso-web/src/main/webapp/scripts/bulk_sample.js
@@ -16,21 +16,6 @@ BulkTarget.sample = (function ($) {
    * }
    */
 
-  var batchRenderQueue = [];
-  var batchRenderTimer = null;
-
-  function setBatchRenderTimer(api) {
-    clearTimeout(batchRenderTimer);
-    batchRenderTimer = setTimeout(function () {
-      var changes = batchRenderQueue.splice(0);
-      api.renderFields(
-        changes.map(function (change)  {
-          return [change.rowIndex, change.columnName, change.value]
-        })
-      )
-    }, 50);
-  }
-
   // stored state when editing probes
   var probeEditingSamples = null;
   var allSamples = null;
@@ -868,25 +853,11 @@ BulkTarget.sample = (function ($) {
                   });
                   setValue = firstReceiptLabel;
                 }
-                var change = {
-                  rowIndex: rowIndex,
-                  columnName: "identityId",
-                  potentialIdentities: potentialIdentities,
-                  value: setValue,
-                  formatter: potentialIdentities.length > 1 ? "multipleOptions" : null
-                }
-                api.updateField(
-                    change.rowIndex,
-                    change.columnName,
-                    {
-                      source: change.potentialIdentities,
-                      value: change.value,
-                      formatter: change.formatter,
-                    },
-                    true);
-
-                batchRenderQueue.push(change);
-                setBatchRenderTimer(api);
+                  api.updateField(rowIndex, "identityId", {
+                    source: potentialIdentities,
+                    value: setValue,
+                    formatter: potentialIdentities.length > 1 ? "multipleOptions" : null,
+                  }, true);
               })
               .fail(function (response, textStatus, serverStatus) {
                 var error = JSON.parse(response.responseText);

--- a/miso-web/src/main/webapp/scripts/bulk_sample.js
+++ b/miso-web/src/main/webapp/scripts/bulk_sample.js
@@ -853,11 +853,11 @@ BulkTarget.sample = (function ($) {
                   });
                   setValue = firstReceiptLabel;
                 }
-                  api.updateField(rowIndex, "identityId", {
-                    source: potentialIdentities,
-                    value: setValue,
-                    formatter: potentialIdentities.length > 1 ? "multipleOptions" : null,
-                  }, true);
+                api.updateField(rowIndex, "identityId", {
+                  source: potentialIdentities,
+                  value: setValue,
+                  formatter: potentialIdentities.length > 1 ? "multipleOptions" : null,
+                }, true);
               })
               .fail(function (response, textStatus, serverStatus) {
                 var error = JSON.parse(response.responseText);


### PR DESCRIPTION
- bulk.js: add skipRender flag to updateField defaulting to previous behavior
- bulk.js: expose renderFields to render changes in bulk
- bulk_sample.js: when resolving the identity lookup callback update the field without rendering
- bulk_sample.js: added a queue and timeout to render fields at once

Jira ticket or GitHub issue:

- [ ] Includes a change file
