### PR TITLE
#3250: add configurable required fields for pools

### DIFF
--- a/changes/add_required_fields_config.md
+++ b/changes/add_required_fields_config.md
@@ -1,0 +1,5 @@
+Configuration to make optional fields required per object type
+* Added `miso.required.pool` property to require specified pool fields
+* Supported pool field: `SIZE`
+* Validation enforced on all save paths including bulk, single-edit, and indirect edits
+* Invalid field names in the configuration cause a startup error

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/RequiredPoolField.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/RequiredPoolField.java
@@ -1,0 +1,31 @@
+package uk.ac.bbsrc.tgac.miso.core.data.type;
+
+import java.util.List;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Pool;
+import uk.ac.bbsrc.tgac.miso.core.service.exception.ValidationError;
+
+public enum RequiredPoolField {
+
+  SIZE("dnaSize") {
+    @Override
+    public void collectValidationErrors(Pool pool, List<ValidationError> errors) {
+      if (pool.getDnaSize() == null) {
+        errors.add(ValidationError.forRequired("dnaSize"));
+      }
+    }
+  };
+
+  private final String fieldName;
+
+  RequiredPoolField(String fieldName) {
+    this.fieldName = fieldName;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public abstract void collectValidationErrors(Pool pool, List<ValidationError> errors);
+
+}

--- a/docs/admin/site-configuration.md
+++ b/docs/admin/site-configuration.md
@@ -409,6 +409,26 @@ Default QC status to apply on bulk create/edit pages. Set to the description of 
 it. When the QC Status column is hidden via `miso.display.bulk.qcStatus`, this value is applied
 automatically on save.
 
+## Required Fields
+
+Fields can be configured as required per object type. Each property takes a comma-separated list of
+supported field names. Invalid names will cause a startup error. All default to empty (no additional
+required fields).
+
+If a field is hidden via `miso.display.bulk.*`, it will not be enforced as required on bulk pages
+since the user would have no way to provide a value. The back-end validation still applies to all
+save paths, including indirect edits such as adding items to transfers or boxes.
+
+If a previously-optional field is changed to required, existing records that are missing a value for
+that field will fail validation on save. The admin is responsible for backfilling existing records
+before enabling a new required field.
+
+### `miso.required.pool`
+
+Comma-separated list of pool fields to require. Supported values: `SIZE`.
+
+Example: `miso.required.pool:SIZE`
+
 ## Index Checking
 
 ### `miso.pools.strictIndexChecking`

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolService.java
@@ -8,7 +8,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -18,6 +20,8 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import jakarta.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +33,7 @@ import com.eaglegenomics.simlims.core.Note;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Box;
 import uk.ac.bbsrc.tgac.miso.core.data.Pool;
+import uk.ac.bbsrc.tgac.miso.core.data.type.RequiredPoolField;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencingOrder;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.OrderLibraryAliquot;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolOrder;
@@ -69,6 +74,11 @@ public class DefaultPoolService implements PoolService {
   @Value("${miso.autoGenerateIdentificationBarcodes}")
   private Boolean autoGenerateIdBarcodes;
 
+  @Value("${miso.required.pool:#{null}}")
+  private String requiredPoolFieldsConfig;
+
+  private List<RequiredPoolField> requiredPoolFields;
+
   @Autowired
   private TransactionTemplate transactionTemplate;
   @Autowired
@@ -99,6 +109,19 @@ public class DefaultPoolService implements PoolService {
   private BarcodableReferenceService barcodableReferenceService;
   @Autowired
   private HibernateUtilDao hibernateUtilDao;
+
+  @PostConstruct
+  private void initRequiredFields() {
+    if (requiredPoolFieldsConfig == null || requiredPoolFieldsConfig.trim().isEmpty()) {
+      requiredPoolFields = Collections.emptyList();
+    } else {
+      requiredPoolFields = Arrays.stream(requiredPoolFieldsConfig.split(","))
+          .map(String::trim)
+          .filter(s -> !s.isEmpty())
+          .map(RequiredPoolField::valueOf)
+          .collect(Collectors.toList());
+    }
+  }
 
   public void setAutoGenerateIdBarcodes(boolean autoGenerateIdBarcodes) {
     this.autoGenerateIdBarcodes = autoGenerateIdBarcodes;
@@ -325,6 +348,10 @@ public class DefaultPoolService implements PoolService {
     validateVolumeUnits(pool.getVolume(), pool.getVolumeUnits(), errors);
     validateBarcodeUniqueness(pool, beforeChange, barcodableReferenceService, errors);
     validateUnboxableFields(pool, errors);
+
+    for (RequiredPoolField field : requiredPoolFields) {
+      field.collectValidationErrors(pool, errors);
+    }
 
     if (strictPools && !pool.isMergeChild()) {
       validateIndices(pool, beforeChange, errors);

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolService.java
@@ -8,9 +8,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -20,8 +18,6 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import jakarta.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -74,9 +70,7 @@ public class DefaultPoolService implements PoolService {
   @Value("${miso.autoGenerateIdentificationBarcodes}")
   private Boolean autoGenerateIdBarcodes;
 
-  @Value("${miso.required.pool:#{null}}")
-  private String requiredPoolFieldsConfig;
-
+  @Value("${miso.required.pool:}")
   private List<RequiredPoolField> requiredPoolFields;
 
   @Autowired
@@ -109,19 +103,6 @@ public class DefaultPoolService implements PoolService {
   private BarcodableReferenceService barcodableReferenceService;
   @Autowired
   private HibernateUtilDao hibernateUtilDao;
-
-  @PostConstruct
-  private void initRequiredFields() {
-    if (requiredPoolFieldsConfig == null || requiredPoolFieldsConfig.trim().isEmpty()) {
-      requiredPoolFields = Collections.emptyList();
-    } else {
-      requiredPoolFields = Arrays.stream(requiredPoolFieldsConfig.split(","))
-          .map(String::trim)
-          .filter(s -> !s.isEmpty())
-          .map(RequiredPoolField::valueOf)
-          .collect(Collectors.toList());
-    }
-  }
 
   public void setAutoGenerateIdBarcodes(boolean autoGenerateIdBarcodes) {
     this.autoGenerateIdBarcodes = autoGenerateIdBarcodes;

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
@@ -60,6 +60,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.IlluminaWorkflowType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.InstrumentType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.MetricCategory;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
+import uk.ac.bbsrc.tgac.miso.core.data.type.RequiredPoolField;
 import uk.ac.bbsrc.tgac.miso.core.data.type.StrStatus;
 import uk.ac.bbsrc.tgac.miso.core.data.type.SubmissionActionType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.ThresholdType;
@@ -250,6 +251,8 @@ public class ConstantsController {
   private boolean showDiscarded;
   @Value("${miso.defaults.bulk.detailedQcStatus:#{null}}")
   private String defaultDetailedQcStatus;
+  @Value("${miso.required.pool:#{null}}")
+  private String requiredPoolFieldsConfig;
 
   @Resource
   private Boolean boxScannerEnabled;
@@ -296,6 +299,16 @@ public class ConstantsController {
       node.put("showMatrixBarcode", showMatrixBarcode);
       node.put("showDiscarded", showDiscarded);
       node.put("defaultDetailedQcStatus", defaultDetailedQcStatus);
+
+      ArrayNode requiredPoolFields = node.putArray("requiredPoolFields");
+      if (requiredPoolFieldsConfig != null) {
+        for (String name : requiredPoolFieldsConfig.split(",")) {
+          String trimmed = name.trim();
+          if (!trimmed.isEmpty()) {
+            requiredPoolFields.add(RequiredPoolField.valueOf(trimmed).getFieldName());
+          }
+        }
+      }
 
       final Collection<SampleValidRelationship> relationships = sampleValidRelationshipService.getAll();
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ConstantsController.java
@@ -251,8 +251,8 @@ public class ConstantsController {
   private boolean showDiscarded;
   @Value("${miso.defaults.bulk.detailedQcStatus:#{null}}")
   private String defaultDetailedQcStatus;
-  @Value("${miso.required.pool:#{null}}")
-  private String requiredPoolFieldsConfig;
+  @Value("${miso.required.pool:}")
+  private List<RequiredPoolField> requiredPoolFields;
 
   @Resource
   private Boolean boxScannerEnabled;
@@ -300,14 +300,9 @@ public class ConstantsController {
       node.put("showDiscarded", showDiscarded);
       node.put("defaultDetailedQcStatus", defaultDetailedQcStatus);
 
-      ArrayNode requiredPoolFields = node.putArray("requiredPoolFields");
-      if (requiredPoolFieldsConfig != null) {
-        for (String name : requiredPoolFieldsConfig.split(",")) {
-          String trimmed = name.trim();
-          if (!trimmed.isEmpty()) {
-            requiredPoolFields.add(RequiredPoolField.valueOf(trimmed).getFieldName());
-          }
-        }
+      ArrayNode requiredPoolFieldsNode = node.putArray("requiredPoolFields");
+      for (RequiredPoolField field : requiredPoolFields) {
+        requiredPoolFieldsNode.add(field.getFieldName());
       }
 
       final Collection<SampleValidRelationship> relationships = sampleValidRelationshipService.getAll();

--- a/miso-web/src/main/resources/miso.properties
+++ b/miso-web/src/main/resources/miso.properties
@@ -101,6 +101,9 @@ miso.display.library.bulk.volume:false
 # miso.display.bulk.discarded:true
 # miso.defaults.bulk.detailedQcStatus:
 
+## required fields configuration (comma-separated list of enum values)
+# miso.required.pool:
+
 ## Strict Index Conflict rules for adding Library Aliquots to Pools.
 ## When enabled, Library Aliquots with duplicate or near-duplicate indices cannot be added to Pools.
 miso.pools.strictIndexChecking:false

--- a/miso-web/src/main/webapp/scripts/bulk.js
+++ b/miso-web/src/main/webapp/scripts/bulk.js
@@ -1963,6 +1963,7 @@ BulkUtils = (function ($) {
         (!tableSaved || !column.hasOwnProperty("includeSaved") || column.includeSaved)
       );
     });
+    applyRequiredOverrides(target, columns);
     var targetDescription = target.getDescription ? target.getDescription(config) : null;
     addQuickHelp(targetDescription, columns);
 
@@ -2473,6 +2474,18 @@ BulkUtils = (function ($) {
       default:
         return false;
     }
+  }
+
+  function applyRequiredOverrides(target, columns) {
+    if (!target.targetKey) return;
+    var key = "required" + target.targetKey.charAt(0).toUpperCase() + target.targetKey.slice(1) + "Fields";
+    var requiredFields = Constants[key];
+    if (!requiredFields || !requiredFields.length) return;
+    columns.forEach(function (column) {
+      if (requiredFields.indexOf(column.data) !== -1 && !isColumnHidden(column.data)) {
+        column.required = true;
+      }
+    });
   }
 
   function getColumnIndex(dataProperty, columns, nullOk) {

--- a/miso-web/src/main/webapp/scripts/bulk_pool.js
+++ b/miso-web/src/main/webapp/scripts/bulk_pool.js
@@ -98,6 +98,7 @@ BulkTarget.pool = (function ($) {
   };
 
   return {
+    targetKey: "pool",
     getSaveUrl: function () {
       return Urls.rest.pools.bulkSave;
     },

--- a/miso-web/src/main/webapp/scripts/form_pool.js
+++ b/miso-web/src/main/webapp/scripts/form_pool.js
@@ -100,7 +100,16 @@ FormTarget.pool = (function ($) {
               initial: Utils.getCurrentDate(),
             },
             FormUtils.makeQcPassedField(),
-            FormUtils.makeDnaSizeField(),
+            (function () {
+              var field = FormUtils.makeDnaSizeField();
+              if (
+                Constants.requiredPoolFields &&
+                Constants.requiredPoolFields.indexOf("dnaSize") !== -1
+              ) {
+                field.required = true;
+              }
+              return field;
+            })(),
             {
               title: "Volume",
               data: "volume",


### PR DESCRIPTION
## Summary
  - Added `miso.required.pool` property to make specified pool fields required
  - Currently supports `SIZE` (insert size / DNA size)
  - Validation enforced on all save paths: single edit form, bulk tables, and indirect edits (transfers, boxes)
  - Invalid field names cause a startup error
  - Front-end marks configured fields as required on both the pool edit form and bulk pool table
  - [x] Includes a change file

  Closes #3250